### PR TITLE
Alias log

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7]
+        python-version: [3.6, 3.7]
 
     steps:
     - uses: actions/checkout@v1

--- a/app/dashboard/templates/dashboard/alias_log.html
+++ b/app/dashboard/templates/dashboard/alias_log.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block default_content %}
-  <div class="page-header row">
+  <div class="page-header row ml-0">
     <h3 class="page-title col">
       {{ alias }}
     </h3>
@@ -16,7 +16,7 @@
   <div class="row">
     {% for log in logs %}
       <div class="col-12">
-        <div class="my-2 p-2 card">
+        <div class="my-2 p-2 card border-light">
           <div class="font-weight-bold">{{ log.when | dt }}</div>
           <div>
             <span class="mr-2">{{ log.website_from or log.website_email }}</span>
@@ -40,6 +40,12 @@
     {% endfor %}
   </div>
 
+  <nav aria-label="Alias log navigation">
+    <ul class="pagination">
+      <li class="page-item {% if page_id == 0 %}disabled{% endif %}"><a class="page-link" href="{{ url_for('dashboard.alias_log', alias=alias, page_id=page_id-1) }}">Previous</a></li>
+      <li class="page-item {% if last_page %}disabled{% endif %}"><a class="page-link" href="{{ url_for('dashboard.alias_log', alias=alias, page_id=page_id+1) }}">Next</a></li>
+    </ul>
+  </nav>
 {% endblock %}
 
 {% block script %}

--- a/app/dashboard/views/alias_log.py
+++ b/app/dashboard/views/alias_log.py
@@ -1,12 +1,14 @@
 from dataclasses import dataclass
 
 import arrow
-from flask import render_template, flash, redirect, url_for
+from flask import render_template, flash, redirect, url_for, abort
 from flask_login import login_required, current_user
 
 from app.dashboard.base import dashboard_bp
 from app.extensions import db
 from app.models import GenEmail, ForwardEmailLog, ForwardEmail
+
+LIMIT = 3
 
 
 @dataclass
@@ -19,9 +21,10 @@ class AliasLog:
     blocked: bool
 
 
-@dashboard_bp.route("/alias_log/<alias>", methods=["GET"])
+@dashboard_bp.route("/alias_log/<alias>", methods=["GET"], defaults={'page_id': 0})
+@dashboard_bp.route("/alias_log/<alias>/<int:page_id>")
 @login_required
-def alias_log(alias):
+def alias_log(alias, page_id):
     gen_email = GenEmail.get_by(email=alias)
 
     # sanity check
@@ -33,19 +36,23 @@ def alias_log(alias):
         flash("You do not have access to this page", "warning")
         return redirect(url_for("dashboard.index"))
 
+    logs = get_alias_log(gen_email, page_id)
+    last_page = len(logs) < LIMIT  # lightweight pagination without counting all objects
+
     return render_template(
-        "dashboard/alias_log.html", logs=get_alias_log(gen_email), alias=alias
+        "dashboard/alias_log.html", **locals()
     )
 
 
-def get_alias_log(gen_email: GenEmail):
+def get_alias_log(gen_email: GenEmail, page_id=0):
     logs: [AliasLog] = []
 
     q = (
         db.session.query(ForwardEmail, ForwardEmailLog)
-        .filter(ForwardEmail.id == ForwardEmailLog.forward_id)
-        .filter(ForwardEmail.gen_email_id == gen_email.id)
-        .all()
+            .filter(ForwardEmail.id == ForwardEmailLog.forward_id)
+            .filter(ForwardEmail.gen_email_id == gen_email.id)
+            .limit(LIMIT)
+            .offset(page_id * LIMIT)
     )
 
     for fe, fel in q:

--- a/app/dashboard/views/alias_log.py
+++ b/app/dashboard/views/alias_log.py
@@ -1,4 +1,5 @@
-from flask import render_template, flash, redirect, url_for, abort
+import arrow
+from flask import render_template, flash, redirect, url_for
 from flask_login import login_required, current_user
 
 from app.dashboard.base import dashboard_bp
@@ -9,14 +10,12 @@ _LIMIT = 15
 
 
 class AliasLog:
-    __slots__ = [
-        "website_email",
-        "website_from",
-        "alias",
-        "when",
-        "is_reply",
-        "blocked",
-    ]  # memory efficiency
+    website_email: str
+    website_from: str
+    alias: str
+    when: arrow.Arrow
+    is_reply: bool
+    blocked: bool
 
     def __init__(self, **kwargs):
         for k, v in kwargs.items():

--- a/app/dashboard/views/alias_log.py
+++ b/app/dashboard/views/alias_log.py
@@ -5,7 +5,7 @@ from app.dashboard.base import dashboard_bp
 from app.extensions import db
 from app.models import GenEmail, ForwardEmailLog, ForwardEmail
 
-LIMIT = 15
+_LIMIT = 15
 
 
 class AliasLog:
@@ -39,7 +39,9 @@ def alias_log(alias, page_id):
         return redirect(url_for("dashboard.index"))
 
     logs = get_alias_log(gen_email, page_id)
-    last_page = len(logs) < LIMIT  # lightweight pagination without counting all objects
+    last_page = (
+        len(logs) < _LIMIT
+    )  # lightweight pagination without counting all objects
 
     return render_template("dashboard/alias_log.html", **locals())
 
@@ -51,8 +53,8 @@ def get_alias_log(gen_email: GenEmail, page_id=0):
         db.session.query(ForwardEmail, ForwardEmailLog)
         .filter(ForwardEmail.id == ForwardEmailLog.forward_id)
         .filter(ForwardEmail.gen_email_id == gen_email.id)
-        .limit(LIMIT)
-        .offset(page_id * LIMIT)
+        .limit(_LIMIT)
+        .offset(page_id * _LIMIT)
     )
 
     for fe, fel in q:

--- a/app/dashboard/views/index.py
+++ b/app/dashboard/views/index.py
@@ -19,7 +19,6 @@ from app.models import (
 )
 
 
-@dataclass
 class AliasInfo:
     gen_email: GenEmail
     nb_forward: int
@@ -28,6 +27,10 @@ class AliasInfo:
 
     show_intro_test_send_email: bool = False
     highlight: bool = False
+
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
 
 
 @dashboard_bp.route("/", methods=["GET", "POST"])

--- a/app/dashboard/views/index.py
+++ b/app/dashboard/views/index.py
@@ -1,5 +1,3 @@
-from dataclasses import dataclass
-
 from flask import render_template, request, redirect, url_for, flash, session
 from flask_login import login_required, current_user
 from sqlalchemy.orm import joinedload


### PR DESCRIPTION
This pr contains:

1. A naive implementation (without creating overhead to count all db objects) of paginate alias log page
2. Try to get rid of `dataclass` dependencies which is Py3.7 only