### PR TITLE
change the smtp response code

### DIFF
--- a/email_handler.py
+++ b/email_handler.py
@@ -244,7 +244,7 @@ class MailHandler:
                 "",
             )
 
-            return "250 ignored"
+            return "450 ignored"
 
         # remove DKIM-Signature
         if msg["DKIM-Signature"]:


### PR DESCRIPTION
I think `250` is when we successfully forward the email, in this case, the email is not forwarded but we refuse to do so, thus `450` is more consistent.