### PR TITLE
Use Cloudflare DNS nameserver

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,8 @@
+.idea/
+*.pyc
 db.sqlite
+.env
+.pytest_cache
+.vscode
+.DS_Store
+config

--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ Later, we will setup Postfix to authorize this network.
 
 ```bash
 docker network create -d bridge \
-    --subnet=1.1.1.0/24 \
-    --gateway=1.1.1.1 \
+    --subnet=240.0.0.0/24 \
+    --gateway=240.0.0.1 \
     sl-network
 ```
 
@@ -238,7 +238,7 @@ sudo postconf -e 'mydomain = mydomain.com'
 sudo postconf -e 'myorigin = mydomain.com'
 sudo postconf -e 'mydestination = localhost'
 
-sudo postconf -e 'mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128 1.1.1.0/24'
+sudo postconf -e 'mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128 240.0.0.0/24'
 
 sudo postconf -e 'relay_domains = pgsql:/etc/postfix/pgsql-relay-domains.cf'
 sudo postconf -e 'transport_maps = pgsql:/etc/postfix/pgsql-transport-maps.cf'

--- a/app/config.py
+++ b/app/config.py
@@ -45,7 +45,7 @@ SUPPORT_EMAIL = os.environ["SUPPORT_EMAIL"]
 ADMIN_EMAIL = os.environ.get("ADMIN_EMAIL")
 MAX_NB_EMAIL_FREE_PLAN = int(os.environ["MAX_NB_EMAIL_FREE_PLAN"])
 # allow to override postfix server locally
-POSTFIX_SERVER = os.environ.get("POSTFIX_SERVER", "1.1.1.1")
+POSTFIX_SERVER = os.environ.get("POSTFIX_SERVER", "240.0.0.1")
 
 # list of (priority, email server)
 EMAIL_SERVERS_WITH_PRIORITY = eval(

--- a/app/dns_utils.py
+++ b/app/dns_utils.py
@@ -4,8 +4,8 @@ import dns.resolver
 def _get_dns_resolver():
     my_resolver = dns.resolver.Resolver()
 
-    # 8.8.8.8 is Google's public DNS server
-    my_resolver.nameservers = ["8.8.8.8"]
+    # 1.1.1.1 is CloudFlare's public DNS server
+    my_resolver.nameservers = ["1.1.1.1"]
 
     return my_resolver
 


### PR DESCRIPTION
- Use CloudFlare DNS nameserver 1.1.1.1
- Replace 1.1.1.0/24 by 240.0.0.0/24 in docker network: 240.0.0.0/4 is a reserved IP https://en.wikipedia.org/wiki/Reserved_IP_addresses
