### PR TITLE
Improve the Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,5 @@ db.sqlite
 .vscode
 .DS_Store
 config
+LICENSE
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,12 @@ FROM python:3.7
 
 WORKDIR /code
 
-# copy everything into /code
-COPY . .
-
 # install dependencies
+COPY ./requirements.txt ./
 RUN pip3 install --no-cache-dir -r requirements.txt
+
+# copy everything else into /code
+COPY . .
 
 EXPOSE 7777
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,14 @@
 FROM python:3.7
 
-RUN apt-get update
-
-RUN apt-get install -y vim
-
 WORKDIR /code
 
-COPY ./requirements.txt ./
-RUN pip3 install -r requirements.txt
-
-
+# copy everything into /code
 COPY . .
+
+# install dependencies
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+EXPOSE 7777
 
 #gunicorn wsgi:app -b 0.0.0.0:7777 -w 2 --timeout 15 --log-level DEBUG
 CMD ["gunicorn","wsgi:app","-b","0.0.0.0:7777","-w","2","--timeout","15"]
-


### PR DESCRIPTION
* reduce number of layers
* remove vim installation (I'm guessing it was here for debug purposes, also this is not a good way to install a package in Docker)
* add LICENSE and README to .dockerignore
* don't cache with pip
* add missing EXPOSE directive

This set of changes reduces the image size by almost 100 Mb!

As a side note, I would recommend renaming this repo to something more meaningful than `app`. When cloning a repo, the organization doesn't appear, only the repo name. In my `$dev` folder, I have several repositories, and their name is the name of the application, imagine if they were all called `app` ;)

Cheers
~Nico