### PR TITLE
Hide seperator from 'from header' if no name present

### DIFF
--- a/email_handler.py
+++ b/email_handler.py
@@ -235,7 +235,7 @@ class MailHandler:
             # replace the email part in from: header
             from_header = (
                 get_email_name(msg["From"])
-                + " - "
+                + ("" if get_email_name(msg["From"]) == "" else " - ")
                 + website_email.replace("@", " at ")
                 + f" <{forward_email.reply_email}>"
             )


### PR DESCRIPTION
If in original message no name is present, email is forwarded like this:
**- hi at simplelogin.io**

This commit adds a conditional to hide the unnecessary seperator.
**hi at simplelogin.io**

Not runtime tested.