### PR TITLE
only send trial-end email to user who is in trial

### DIFF
--- a/cron.py
+++ b/cron.py
@@ -22,7 +22,9 @@ def notify_trial_end():
     for user in User.query.filter(
         User.activated == True, User.trial_end.isnot(None), User.lifetime == False
     ).all():
-        if arrow.now().shift(days=3) > user.trial_end >= arrow.now().shift(days=2):
+        if user.in_trial() and arrow.now().shift(
+            days=3
+        ) > user.trial_end >= arrow.now().shift(days=2):
             LOG.d("Send trial end email to user %s", user)
             send_trial_end_soon_email(user)
 


### PR DESCRIPTION
i.e. users who:
1. has lifetime licence or active subscription and
2. is in trial period