### PR TITLE
🐛 WebAuthn bug fixes

### DIFF
--- a/app/auth/views/fido.py
+++ b/app/auth/views/fido.py
@@ -42,7 +42,7 @@ def fido():
     webauthn_user = webauthn.WebAuthnUser(
         user.fido_uuid,
         user.email,
-        user.name,
+        user.name if user.name else user.email,
         False,
         user.fido_credential_id,
         user.fido_pk,

--- a/app/dashboard/views/fido_setup.py
+++ b/app/dashboard/views/fido_setup.py
@@ -81,9 +81,10 @@ def fido_setup():
         RP_ID,
         fido_uuid,
         current_user.email,
-        current_user.name,
+        current_user.name if current_user.name else current_user.email,
         False,
         attestation="none",
+        user_verification="discouraged",
     )
 
     # Don't think this one should be used, but it's not configurable by arguments


### PR DESCRIPTION
- User may not have a name - didn't realize this since the local fake data have it as default
- user_verification should be discouraged to work on iOS

