### PR TITLE
Session cookie flags.

### DIFF
--- a/app/extensions.py
+++ b/app/extensions.py
@@ -5,4 +5,5 @@ from flask_sqlalchemy import SQLAlchemy
 
 db = SQLAlchemy()
 login_manager = LoginManager()
+login_manager.session_protection = "strong"
 migrate = Migrate(db=db)

--- a/server.py
+++ b/server.py
@@ -83,6 +83,9 @@ def create_app() -> Flask:
 
     # to avoid conflict with other cookie
     app.config["SESSION_COOKIE_NAME"] = "slapp"
+    if URL.startswith("https"):
+        app.config["SESSION_COOKIE_SECURE"] = True
+    app.config["SESSION_COOKIE_SAMESITE"] = "strict"
 
     init_extensions(app)
     register_blueprints(app)


### PR DESCRIPTION
Currently firefox displays this warning:
```
Cookie “slapp” will be soon rejected because it has the “sameSite” attribute set to
“none” or an invalid value, without the “secure” attribute.
To know more about the “sameSite“ attribute,
read https://developer.mozilla.org/docs/Web/HTTP/Cookies
```
- This commit sets the 'secure' flag to true when the base url starts with https
- Set the SameSite attribute to 'strict'
- Set Flask session_protection to 'strong' (see https://flask-login.readthedocs.io/en/latest/#session-protection)