### PR TITLE
Frontend improvements

### DIFF
--- a/app/dashboard/templates/dashboard/alias_log.html
+++ b/app/dashboard/templates/dashboard/alias_log.html
@@ -145,12 +145,13 @@
 
   <nav aria-label="Alias log navigation">
     <ul class="pagination">
-      <li class="page-item {% if page_id == 0 %}disabled{% endif %}">
-        <a class="btn btn-outline-secondary"
+      <li class="page-item">
+        <a class="btn btn-outline-secondary {% if page_id == 0 %}disabled{% endif %}"
            href="{{ url_for('dashboard.alias_log', alias_id=alias_id, page_id=page_id-1) }}">Previous</a>
       </li>
-      <li class="page-item {% if last_page %}disabled{% endif %}">
-        <a class="btn btn-outline-secondary" href="{{ url_for('dashboard.alias_log', alias_id=alias_id, page_id=page_id+1) }}">Next</a>
+      <li class="page-item">
+        <a class="btn btn-outline-secondary {% if last_page %}disabled{% endif %}"
+           href="{{ url_for('dashboard.alias_log', alias_id=alias_id, page_id=page_id+1) }}">Next</a>
       </li>
     </ul>
   </nav>

--- a/app/dashboard/templates/dashboard/alias_log.html
+++ b/app/dashboard/templates/dashboard/alias_log.html
@@ -146,11 +146,11 @@
   <nav aria-label="Alias log navigation">
     <ul class="pagination">
       <li class="page-item {% if page_id == 0 %}disabled{% endif %}">
-        <a class="page-link"
+        <a class="btn btn-outline-secondary"
            href="{{ url_for('dashboard.alias_log', alias_id=alias_id, page_id=page_id-1) }}">Previous</a>
       </li>
       <li class="page-item {% if last_page %}disabled{% endif %}">
-        <a class="page-link" href="{{ url_for('dashboard.alias_log', alias_id=alias_id, page_id=page_id+1) }}">Next</a>
+        <a class="btn btn-outline-secondary" href="{{ url_for('dashboard.alias_log', alias_id=alias_id, page_id=page_id+1) }}">Next</a>
       </li>
     </ul>
   </nav>

--- a/app/dashboard/templates/dashboard/index.html
+++ b/app/dashboard/templates/dashboard/index.html
@@ -400,13 +400,15 @@
     <div class="col">
       <nav aria-label="Alias navigation">
         <ul class="pagination">
-          <li class="page-item {% if page == 0 %}disabled{% endif %}">
-            <a class="page-link"
-               href="{{ url_for('dashboard.index', page=page-1, query=query, sort=sort, filter=filter) }}">Previous</a>
+          <li class="page-item">
+            <a class="btn btn-outline-secondary {% if page == 0 %}disabled{% endif %}"
+               href="{{ url_for('dashboard.index', page=page-1, query=query, sort=sort, filter=filter) }}">
+              Previous</a>
           </li>
-          <li class="page-item {% if last_page %}disabled{% endif %}">
-            <a class="page-link"
-               href="{{ url_for('dashboard.index', page=page+1, query=query, sort=sort, filter=filter) }}">Next</a>
+          <li class="page-item">
+            <a class="btn btn-outline-secondary {% if last_page %}disabled{% endif %}"
+               href="{{ url_for('dashboard.index', page=page+1, query=query, sort=sort, filter=filter) }}">
+              Next</a>
           </li>
         </ul>
       </nav>

--- a/app/dashboard/views/index.py
+++ b/app/dashboard/views/index.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-
 from flask import render_template, request, redirect, url_for, flash
 from flask_login import login_required, current_user
 from sqlalchemy.orm import joinedload
@@ -144,9 +143,7 @@ def index():
     alias_infos = get_alias_infos_with_pagination_v2(
         current_user, page, query, sort, alias_filter
     )
-    last_page = (
-            len(alias_infos) < PAGE_LIMIT
-    )
+    last_page = len(alias_infos) < PAGE_LIMIT
 
     return render_template(
         "dashboard/index.html",

--- a/app/dashboard/views/index.py
+++ b/app/dashboard/views/index.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import joinedload
 
 from app import alias_utils
 from app.api.serializer import get_alias_infos_with_pagination_v2
+from app.config import PAGE_LIMIT
 from app.dashboard.base import dashboard_bp
 from app.extensions import db
 from app.log import LOG
@@ -140,18 +141,24 @@ def index():
 
     stats = get_stats(current_user)
 
+    alias_infos = get_alias_infos_with_pagination_v2(
+        current_user, page, query, sort, alias_filter
+    )
+    last_page = (
+            len(alias_infos) < PAGE_LIMIT
+    )
+
     return render_template(
         "dashboard/index.html",
         client_users=client_users,
-        alias_infos=get_alias_infos_with_pagination_v2(
-            current_user, page, query, sort, alias_filter
-        ),
+        alias_infos=alias_infos,
         highlight_alias_id=highlight_alias_id,
         query=query,
         AliasGeneratorEnum=AliasGeneratorEnum,
         mailboxes=mailboxes,
         show_intro=show_intro,
         page=page,
+        last_page=last_page,
         sort=sort,
         filter=alias_filter,
         stats=stats,

--- a/static/assets/css/darkmode.css
+++ b/static/assets/css/darkmode.css
@@ -9,7 +9,7 @@
     --heading-color: #818cab;
     --heading-background: #FFF;
     --border: 1px solid rgba(0, 40, 100, 0.12);
-    --input-bg-color: var(--light);
+    --input-bg-color: var(--white);
 }
 
 [data-theme="dark"] {

--- a/static/assets/js/core.js
+++ b/static/assets/js/core.js
@@ -104,17 +104,4 @@ $(document).ready(function() {
       });
     });
   }
-
-  /** Dark mode controller */
-  if (store.get('dark-mode') === true) {
-    document.documentElement.setAttribute('data-theme', 'dark')
-  }
-  $('[data-toggle="dark-mode"]').on('click', function () {
-    if (store.get('dark-mode') === true) {
-      store.set('dark-mode', false);
-      return document.documentElement.setAttribute('data-theme', 'light')
-    }
-    store.set('dark-mode', true)
-    document.documentElement.setAttribute('data-theme', 'dark')
-  })
 });

--- a/static/assets/js/theme.js
+++ b/static/assets/js/theme.js
@@ -1,0 +1,40 @@
+let setCookie = function(name, value, days) {
+    if (!name || !value) return false;
+    let expires = '';
+    let secure = '';
+    if (location.protocol === 'https:') secure = 'Secure; ';
+
+    if (days) {
+      let date = new Date();
+      date.setTime(date.getTime() + (days * 24*60*60*1000));
+      expires = 'Expires=' + date.toUTCString() + '; ';
+    }
+
+    document.cookie = name + '=' + value + '; ' +
+                      expires +
+                      secure +
+                      'sameSite=Lax; ' +
+                      'domain=' + window.location.hostname + '; ' +
+                      'path=/';
+    return true;
+  }
+
+let getCookie = function(name) {
+  let match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+  if (match) return match[2];
+}
+
+$(document).ready(function() {
+  /** Dark mode controller */
+  if (getCookie('dark-mode') === "true") {
+    document.documentElement.setAttribute('data-theme', 'dark');
+  }
+  $('[data-toggle="dark-mode"]').on('click', function () {
+    if (getCookie('dark-mode') === "true") {
+      setCookie('dark-mode', 'false', 30);
+      return document.documentElement.setAttribute('data-theme', 'light')
+    }
+    setCookie('dark-mode', 'true', 30);
+    document.documentElement.setAttribute('data-theme', 'dark')
+  })
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,7 +1,7 @@
 {% from "_formhelpers.html" import render_field, render_field_errors %}
 
 <!doctype html>
-<html lang="en" dir="ltr">
+<html lang="en" dir="ltr" data-theme="{% if request.cookies.get('dark-mode') == 'true' %}dark{% endif %}">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport"
@@ -39,6 +39,8 @@
   <script src="/static/assets/js/vendors/jquery-jvectormap-world-mill.js"></script>
   <script src="/static/assets/js/vendors/circle-progress.min.js"></script>
   <script src="/static/assets/js/core.js"></script>
+
+  <script src="/static/assets/js/theme.js"></script>
 
   <!-- ClipboardJS -->
   <script src="/static/vendor/clipboard.min.js"></script>

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -33,8 +33,7 @@
       </div>
       <div class="col-12 col-lg-auto mt-3 mt-lg-0 text-center">
         Copyright © {{ YEAR }}
-        <a href="https://simplelogin.io" target="_blank">SimpleLogin
-        </a>.
+        <a href="https://simplelogin.io" target="_blank">SimpleLogin</a>.
         All rights reserved.
       </div>
     </div>


### PR DESCRIPTION
1. **When using the dark theme, the page flashes white before loading javascript (my eyes!).**
This commit stores the dark theme setting in a cookie, instead of the local store. This way the server can send the HTML with the correct data attribute, preventing the page from starting to draw the light theme for a few frames.
2. **Small space fix**
Before
![image](https://user-images.githubusercontent.com/5833571/81933846-47f1b780-95ee-11ea-95bc-f7dc3d12350e.png)
After
![image](https://user-images.githubusercontent.com/5833571/81933868-4de79880-95ee-11ea-80f5-e8862cac508c.png)
3. **Change pagination style to fit better in the dark theme.**
Before
![image](https://user-images.githubusercontent.com/5833571/81933921-62c42c00-95ee-11ea-808e-da84a591a35c.png)
After
![image](https://user-images.githubusercontent.com/5833571/81933929-6788e000-95ee-11ea-83c4-f0c73be25077.png)
4. **Fix last_page check on index and alias_log.**
This correctly disables the next/previous button on those pages. (They currently allow you to go past the boundaries)
5. **Set input background to white for the light theme (looks better I think)**
Before
![image](https://user-images.githubusercontent.com/5833571/81934167-cbaba400-95ee-11ea-8ccf-f31788b33c5e.png)
After
![image](https://user-images.githubusercontent.com/5833571/81934262-f85fbb80-95ee-11ea-9ca1-fc4217a90f7b.png)

