### PR TITLE
Move api error handling to global error handler

### DIFF
--- a/app/api/base.py
+++ b/app/api/base.py
@@ -33,19 +33,3 @@ def require_api_auth(f):
         return f(*args, **kwargs)
 
     return decorated
-
-
-@api_bp.app_errorhandler(404)
-def not_found(e):
-    return jsonify(error="No such endpoint"), 404
-
-
-@api_bp.app_errorhandler(Exception)
-def internal_error(e):
-    LOG.exception(e)
-    return jsonify(error="Internal error"), 500
-
-
-@api_bp.app_errorhandler(405)
-def wrong_method(e):
-    return jsonify(error="Method not allowed"), 405

--- a/server.py
+++ b/server.py
@@ -328,26 +328,48 @@ def setup_openid_metadata(app):
 
 def setup_error_page(app):
     @app.errorhandler(400)
-    def page_not_found(e):
-        return render_template("error/400.html"), 400
+    def bad_request(e):
+        if request.path.startswith("/api/"):
+            return jsonify(error="Bad Request"), 400
+        else:
+            return render_template("error/400.html"), 400
 
     @app.errorhandler(401)
-    def page_not_found(e):
-        flash("You need to login to see this page", "error")
-        return redirect(url_for("auth.login", next=request.full_path))
+    def unauthorized(e):
+        if request.path.startswith("/api/"):
+            return jsonify(error="Unauthorized"), 401
+        else:
+            flash("You need to login to see this page", "error")
+            return redirect(url_for("auth.login", next=request.full_path))
 
     @app.errorhandler(403)
-    def page_not_found(e):
-        return render_template("error/403.html"), 403
+    def forbidden(e):
+        if request.path.startswith("/api/"):
+            return jsonify(error="Forbidden"), 403
+        else:
+            return render_template("error/403.html"), 403
 
     @app.errorhandler(404)
     def page_not_found(e):
-        return render_template("error/404.html"), 404
+        if request.path.startswith("/api/"):
+            return jsonify(error="No such endpoint"), 404
+        else:
+            return render_template("error/404.html"), 404
+
+    @app.errorhandler(405)
+    def wrong_method(e):
+        if request.path.startswith("/api/"):
+            return jsonify(error="Method not allowed"), 405
+        else:
+            return render_template("error/405.html"), 405
 
     @app.errorhandler(Exception)
     def error_handler(e):
         LOG.exception(e)
-        return render_template("error/500.html"), 500
+        if request.path.startswith("/api/"):
+            return jsonify(error="Internal error"), 500
+        else:
+            return render_template("error/500.html"), 500
 
 
 def setup_favicon_route(app):

--- a/templates/error/405.html
+++ b/templates/error/405.html
@@ -1,0 +1,15 @@
+{% extends "error.html" %}
+
+{% block error_name %}
+  405
+{% endblock %}
+
+{% block error_description %}
+  Client used wrong method when accessing resource.
+{% endblock %}
+
+{% block suggestion %}
+  <a class="btn btn-primary" href="javascript:history.back()">
+    <i class="fe fe-arrow-left mr-2"></i>Go Back
+  </a>
+{% endblock %}


### PR DESCRIPTION
Move API error handling. Dashboard currently does not show the HTML error page. Only return json if request URL starts with /api/.

Test with:
```
http https://app.simplelogin.io/dashboard/not_existing
http https://app.simplelogin.io/api/not_existing
```