### PR TITLE
Implement rate limiting

### DIFF
--- a/app/auth/views/fido.py
+++ b/app/auth/views/fido.py
@@ -9,6 +9,7 @@ from flask import (
     flash,
     session,
     make_response,
+    g,
 )
 from flask_login import login_user
 from flask_wtf import FlaskForm
@@ -17,7 +18,7 @@ from wtforms import HiddenField, validators, BooleanField
 from app.auth.base import auth_bp
 from app.config import MFA_USER_ID
 from app.config import RP_ID, URL
-from app.extensions import db
+from app.extensions import db, limiter
 from app.log import LOG
 from app.models import User, Fido, MfaBrowser
 
@@ -30,6 +31,9 @@ class FidoTokenForm(FlaskForm):
 
 
 @auth_bp.route("/fido", methods=["GET", "POST"])
+@limiter.limit(
+    "10/minute", deduct_when=lambda r: hasattr(g, "deduct_limit") and g.deduct_limit
+)
 def fido():
     # passed from login page
     user_id = session.get(MFA_USER_ID)
@@ -57,6 +61,9 @@ def fido():
             flash(f"Welcome back {user.name}!", "success")
             # Redirect user to correct page
             return redirect(next_url or url_for("dashboard.index"))
+        else:
+            # Trigger rate limiter
+            g.deduct_limit = True
 
     # Handling POST requests
     if fido_token_form.validate_on_submit():
@@ -89,6 +96,8 @@ def fido():
         except Exception as e:
             LOG.error(f"An error occurred in WebAuthn verification process: {e}")
             flash("Key verification failed.", "warning")
+            # Trigger rate limiter
+            g.deduct_limit = True
             auto_activate = False
         else:
             user.fido_sign_count = new_sign_count

--- a/app/auth/views/forgot_password.py
+++ b/app/auth/views/forgot_password.py
@@ -1,9 +1,10 @@
-from flask import request, render_template, redirect, url_for, flash
+from flask import request, render_template, redirect, url_for, flash, g
 from flask_wtf import FlaskForm
 from wtforms import StringField, validators
 
 from app.auth.base import auth_bp
 from app.dashboard.views.setting import send_reset_password_email
+from app.extensions import limiter
 from app.models import User
 
 
@@ -12,6 +13,9 @@ class ForgotPasswordForm(FlaskForm):
 
 
 @auth_bp.route("/forgot_password", methods=["GET", "POST"])
+@limiter.limit(
+    "10/minute", deduct_when=lambda r: hasattr(g, "deduct_limit") and g.deduct_limit
+)
 def forgot_password():
     form = ForgotPasswordForm(request.form)
 
@@ -27,5 +31,8 @@ def forgot_password():
         if user:
             send_reset_password_email(user)
             return redirect(url_for("auth.forgot_password"))
+
+        # Trigger rate limiter
+        g.deduct_limit = True
 
     return render_template("auth/forgot_password.html", form=form)

--- a/app/extensions.py
+++ b/app/extensions.py
@@ -1,9 +1,22 @@
+from flask import request
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
 from flask_login import LoginManager
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
-
 
 db = SQLAlchemy()
 login_manager = LoginManager()
 login_manager.session_protection = "strong"
 migrate = Migrate(db=db)
+
+# Setup rate limit facility
+limiter = Limiter(key_func=get_remote_address)
+
+
+@limiter.request_filter
+def ip_whitelist():
+    # Uncomment line to test rate limit in dev environment
+    # return False
+    # No limit for local development
+    return request.remote_addr == "127.0.0.1"

--- a/requirements.in
+++ b/requirements.in
@@ -40,3 +40,4 @@ google-auth-httplib2
 python-gnupg
 webauthn
 pyspf
+Flask-Limiter

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,12 +37,13 @@ flask-admin==1.5.3        # via -r requirements.in
 flask-cors==3.0.8         # via -r requirements.in
 flask-debugtoolbar==0.10.1  # via -r requirements.in
 flask-httpauth==3.3.0     # via flask-profiler
+flask-limiter==1.3.1      # via -r requirements.in
 flask-login==0.4.1        # via -r requirements.in
 flask-migrate==2.5.2      # via -r requirements.in
 flask-profiler==1.8.1     # via -r requirements.in
 flask-sqlalchemy==2.4.0   # via -r requirements.in, flask-migrate
 flask-wtf==0.14.2         # via -r requirements.in
-flask==1.0.3              # via -r requirements.in, flask-admin, flask-cors, flask-debugtoolbar, flask-httpauth, flask-login, flask-migrate, flask-profiler, flask-sqlalchemy, flask-wtf
+flask==1.0.3              # via -r requirements.in, flask-admin, flask-cors, flask-debugtoolbar, flask-httpauth, flask-limiter, flask-login, flask-migrate, flask-profiler, flask-sqlalchemy, flask-wtf
 future==0.18.2            # via webauthn
 google-api-python-client==1.7.11  # via -r requirements.in
 google-auth-httplib2==0.0.3  # via -r requirements.in, google-api-python-client
@@ -59,6 +60,7 @@ jedi==0.13.3              # via ipython
 jinja2==2.10.1            # via flask, yacron
 jmespath==0.9.4           # via boto3, botocore
 jwcrypto==0.6.0           # via -r requirements.in
+limits==1.5.1             # via flask-limiter
 mako==1.0.12              # via alembic
 markupsafe==1.1.1         # via jinja2, mako
 more-itertools==7.0.0     # via pytest
@@ -98,7 +100,7 @@ ruamel.yaml==0.15.97      # via strictyaml
 s3transfer==0.2.1         # via boto3
 sentry-sdk==0.14.1        # via -r requirements.in
 simplejson==3.17.0        # via flask-profiler
-six==1.12.0               # via bcrypt, cryptography, flask-cors, google-api-python-client, google-auth, packaging, pip-tools, prompt-toolkit, pyopenssl, pytest, python-dateutil, sqlalchemy-utils, traitlets, webauthn
+six==1.12.0               # via bcrypt, cryptography, flask-cors, flask-limiter, google-api-python-client, google-auth, limits, packaging, pip-tools, prompt-toolkit, pyopenssl, pytest, python-dateutil, sqlalchemy-utils, traitlets, webauthn
 sqlalchemy-utils==0.36.1  # via -r requirements.in
 sqlalchemy==1.3.12        # via alembic, flask-sqlalchemy, sqlalchemy-utils
 strictyaml==1.0.2         # via yacron

--- a/templates/error/429.html
+++ b/templates/error/429.html
@@ -1,0 +1,15 @@
+{% extends "error.html" %}
+
+{% block error_name %}
+  429
+{% endblock %}
+
+{% block error_description %}
+  Whoa, slow down there, pardner!
+{% endblock %}
+
+{% block suggestion %}
+  <a class="btn btn-primary" href="/">
+    <i class="fe fe-home mr-2"></i>Home Page
+  </a>
+{% endblock %}


### PR DESCRIPTION
Based on #199 #203. 
Implementation for rate limiting, specified limit is per IP.
- Puts limit on endpoints like username/password authentication and mfa endpoints.
- Only counts 'bad requests', e.g. failed login attempt.
- I arbitrarily chose 10/min limit. Any thoughts? As it's only failed requests, we could possibly lower this. More complex limits are possible:
```
@limiter.limit("100/day;10/hour;1/minute")
```

Nginx snippet
```
server {
    server_name  app.mydomain.com;

    location / {
        proxy_pass http://localhost:7777;
        proxy_set_header X-Forwarded-For $remote_addr;
    }
}
```