### PR TITLE
Add dot after DKIM

### DIFF
--- a/app/dashboard/templates/dashboard/domain_detail/dns.html
+++ b/app/dashboard/templates/dashboard/domain_detail/dns.html
@@ -178,7 +178,7 @@
             title="Click to copy"
             class="clipboard"
             data-clipboard-text="{{ dkim_cname }}" style="overflow-wrap: break-word">
-          {{ dkim_cname }}
+          {{ dkim_cname }}.
         </em>
       </div>
 


### PR DESCRIPTION
When I was setting up SimpleLogin (cool stuff by the way), DKIM went wrong because the record ended up being converted to `dkim._domainkey.simplelogin.co.example.com` due to the lack to ending dot.

This PR proposes adding a `.` at the end of the Value in the DNS screen to hopefully prevent others from making my mistake.

Please note: I haven't tested this myself, haven't bothered setting up the Docker container yet.