### PR TITLE
Dedupe email address

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1181,19 +1181,16 @@ class Contact(db.Model, ModelMixin):
             or user.sender_format == SenderFormatEnum.VIA.value
         ):
             new_name = f"{self.website_email} via SimpleLogin"
-        elif user.sender_format == SenderFormatEnum.AT.value:
-            name = self.name or ""
-            new_name = (
-                name + (" - " if name else "") + self.website_email.replace("@", " at ")
-            ).strip()
-        elif user.sender_format == SenderFormatEnum.A.value:
-            name = self.name or ""
-            new_name = (
-                name + (" - " if name else "") + self.website_email.replace("@", "(a)")
-            ).strip()
-        elif user.sender_format == SenderFormatEnum.FULL.value:
-            name = self.name or ""
-            new_name = (name + (" - " if name else "") + self.website_email).strip()
+        else:
+            if user.sender_format == SenderFormatEnum.AT.value:
+                formatted_email = self.website_email.replace("@", " at ").strip()
+            elif user.sender_format == SenderFormatEnum.A.value:
+                formatted_email = self.website_email.replace("@", "(a)").strip()
+            elif user.sender_format == SenderFormatEnum.FULL.value:
+                formatted_email = self.website_email.strip()
+
+            # Prefix name to formatted email if available
+            new_name = (self.name + " - " + formatted_email) if self.name and self.name != self.website_email.strip() else formatted_email
 
         new_addr = formataddr((new_name, self.reply_email)).strip()
         return new_addr.strip()

--- a/app/models.py
+++ b/app/models.py
@@ -1190,7 +1190,11 @@ class Contact(db.Model, ModelMixin):
                 formatted_email = self.website_email.strip()
 
             # Prefix name to formatted email if available
-            new_name = (self.name + " - " + formatted_email) if self.name and self.name != self.website_email.strip() else formatted_email
+            new_name = (
+                (self.name + " - " + formatted_email)
+                if self.name and self.name != self.website_email.strip()
+                else formatted_email
+            )
 
         new_addr = formataddr((new_name, self.reply_email)).strip()
         return new_addr.strip()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -133,8 +133,19 @@ def test_new_addr(flask_client):
     )
     assert c1.new_addr() == '"abcd@example.com via SimpleLogin" <rep@SL>'
 
+    # set sender format = FULL
+    user.sender_format = SenderFormatEnum.FULL.value
+    db.session.commit()
+    assert c1.new_addr() == '"First Last - abcd@example.com" <rep@SL>'
+
+    # Make sure email isn't duplicated if sender name equals email
+    c1.name = "abcd@example.com"
+    db.session.commit()
+    assert c1.new_addr() == '"abcd@example.com" <rep@SL>'
+
     # set sender_format = AT
     user.sender_format = SenderFormatEnum.AT.value
+    c1.name = "First Last"
     db.session.commit()
     assert c1.new_addr() == '"First Last - abcd at example.com" <rep@SL>'
 


### PR DESCRIPTION
I sometimes get emails where the sender's name is the same as the email address. This causes the same info to be displayed twice. This code deduplicates it.

So, if you get an email like `From: example@example.com <example@example.com>` it should only display as `example@example.com <reply_address>` instead of `example@example.com - example@example.com <reply_address>`.

I hope this code and change is useful to you. Feel free to tell me if you want any changes.