### PR TITLE
Show icon if address was autogenerated

### DIFF
--- a/app/dashboard/templates/dashboard/index.html
+++ b/app/dashboard/templates/dashboard/index.html
@@ -193,6 +193,7 @@
               >
                 <span class="font-weight-bold">{{ alias.email }}</span>
               </span>
+              {% if alias.automatic_creation %} <span class="fa fa-inbox" data-toggle="tooltip" title="This alias was automatically generated because of an incoming email"></span>{% endif %}
             </div>
             <div class="col text-right">
               <label class="custom-switch cursor"


### PR DESCRIPTION
Choosing an icon for this is HARD. I ended up going with `fa-inbox` because it was generated because of an auto-generated email and I couldn't find any better icon on https://fontawesome.com/icons?d=gallery&m=free. However, if you have a suggestion, I'll gladly change it.

![image](https://user-images.githubusercontent.com/1885159/94957651-65b4b000-04ee-11eb-8500-25e4dafc83e4.png)
