### PR TITLE
add docker-compose examples and apache2 setup to self host instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ sudo apt-get install -y postfix postfix-pgsql -y
 
 Choose "Internet Site" in Postfix installation window then keep using the proposed value as *System mail name* in the next window.
 
-to make sure pgsql is working correctly, run `postconf -m` and make sure its listed.
+to make sure pgsql is working correctly, run `postconf -m` and make sure `pgsql` is listed.
 
 Replace `/etc/postfix/main.cf` with the following content. Make sure to replace `mydomain.com` by your domain.
 
@@ -536,7 +536,47 @@ sudo docker run --rm \
     simplelogin/app:3.2.2 python init_app.py
 ```
 
-Now, it's time to run the `webapp` container!
+now it time to setup the `webapp` and `email handler` containers
+
+for docker-compose add this to your file:
+
+```
+    simplelogin:
+        image: simplelogin/app:3.2.2
+        container_name: sl-app
+        ports:
+            - "8009:7777"
+        restart: unless-stopped
+        volumes:
+        # this is to add more words to create more unique aliases
+        # - ./words.txt:/code/local_data/words.txt
+        - ./sl:/sl
+        - ./sl/upload:/code/static/upload
+        - ./simplelogin.env:/code/.env
+        - ./dkim.key:/dkim.key
+        - ./dkim.pub.key:/dkim.pub.key
+
+    simplelogin-email_handler:
+        image: simplelogin/app:3.2.2
+        container_name: sl-email
+        command: python email_handler.py
+        ports:
+            - "20381:20381"
+        restart: unless-stopped
+        volumes:
+        # this is to add more words to create more unique aliases you have to create a word.txt file.
+        # - ./words.txt:/code/local_data/words.txt
+        - ./sl:/sl
+        - ./sl/upload:/code/static/upload
+        - ./simplelogin.env:/code/.env
+        - ./dkim.key:/dkim.key
+        - ./dkim.pub.key:/dkim.pub.key
+
+```
+
+for docker-cli:
+
+`webapp` container:
 
 ```bash
 sudo docker run -d \
@@ -552,7 +592,7 @@ sudo docker run -d \
     simplelogin/app:3.2.2
 ```
 
-Next run the `email handler`
+`email handler` container:
 
 ```bash
 sudo docker run -d \

--- a/README.md
+++ b/README.md
@@ -350,6 +350,8 @@ sudo apt-get install -y postfix postfix-pgsql -y
 
 Choose "Internet Site" in Postfix installation window then keep using the proposed value as *System mail name* in the next window.
 
+to make sure pgsql is working correctly, run `postconf -m` and make sure its listed.
+
 Replace `/etc/postfix/main.cf` with the following content. Make sure to replace `mydomain.com` by your domain.
 
 ```

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ sudo docker run -d \
     postgres:12.1
 ```
 
-if you want to use docker-compose you can paste this inside your docker-compose.yml file
+if you want to use docker-compose you can paste this inside your `docker-compose.yml` file
 
 ```
 version: "3"
@@ -368,6 +368,10 @@ readme_directory = no
 # See http://www.postfix.org/COMPATIBILITY_README.html -- default to 2 on
 # fresh installs.
 compatibility_level = 2
+
+# if you have an issue local recipient tables uncomment the nextline to 
+# remove the table completely
+# local_recipient_maps = 
 
 # TLS parameters
 smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem

--- a/README.md
+++ b/README.md
@@ -305,6 +305,33 @@ sudo docker run -d \
     postgres:12.1
 ```
 
+if you want to use docker-compose you can paste this inside your docker-compose.yml file
+
+```
+version: "3"
+#connecting to the pre made sl-network.
+networks:
+    default:
+        external:
+            name: sl-network
+
+# all file paths are relative to the docker-compose file
+
+services:
+    postgres:
+        image: postgres:12.1
+        container_name: sl-db
+        ports:
+            - "5432:5432"
+        volumes:
+            - ./sl/db:/var/lib/postgresql/data
+        environment:
+            - POSTGRES_PASSWORD=mypassword
+            - POSTGRES_USER=myuser
+            - POSTGRES_DB=simplelogin
+        restart: unless-stopped
+```
+
 To test whether the database operates correctly or not, run the following command:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -655,6 +655,39 @@ sudo systemctl reload nginx
 
 At this step, you should also setup the SSL for Nginx. [Certbot](https://certbot.eff.org/lets-encrypt/ubuntuxenial-nginx) can be a good option if you want a free SSL certificate.
 
+
+### Apache
+
+Install Apache and make sure to replace `mydomain.com` by your domain
+
+```bash
+sudo apt-get install -y apache2
+```
+```
+<IfModule mod_ssl.c>
+  <VirtualHost _default_:443>
+    ServerName mydomain.com
+    DocumentRoot /var/www/html
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    SSLEngine on
+    SSLCertificateFile      /etc/ssl/certs/ssl-cert-snakeoil.pem
+    SSLCertificateKeyFile /etc/ssl/private/ssl-cert-snakeoil.key
+    ProxyPreserveHost On
+    ProxyPass / http://127.0.0.1:7777/
+    ProxyPassReverse / http://127.0.0.1:7777/
+    <FilesMatch "\.(cgi|shtml|phtml|php)$">
+      SSLOptions +StdEnvVars
+    </FilesMatch>
+    <Directory /usr/lib/cgi-bin>
+      SSLOptions +StdEnvVars
+    </Directory>
+  </VirtualHost>
+</IfModule>
+```
+
+this will use the default self-signed cert.
+
 ### Enjoy!
 
 If all of the above steps are successful, open http://app.mydomain.com/ and create your first account!

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ---
 <p>
 <a href="https://chrome.google.com/webstore/detail/dphilobhebphkdjbpfohgikllaljmgbn">
-    <img src="https://img.shields.io/chrome-web-store/rating/dphilobhebphkdjbpfohgikllaljmgbn?label=Chrome%20Extension">
+    <img src="https://img.shields.io/chrome-web-store/v/dphilobhebphkdjbpfohgikllaljmgbn">
 </a>
 
 <a href="https://addons.mozilla.org/firefox/addon/simplelogin/">

--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ for docker-compose add this to your file:
         image: simplelogin/app:3.2.2
         container_name: sl-app
         ports:
-            - "8009:7777"
+            - "7777:7777"
         restart: unless-stopped
         volumes:
         # this is to add more words to create more unique aliases

--- a/README.md
+++ b/README.md
@@ -659,8 +659,16 @@ At this step, you should also setup the SSL for Nginx. [Certbot](https://certbot
 
 If all of the above steps are successful, open http://app.mydomain.com/ and create your first account!
 
-By default, new accounts are not premium so don't have unlimited alias. To make your account premium,
-please go to the database, table "users" and set "lifetime" column to "1" or "TRUE".
+By default, new accounts are **not premium** so don't have unlimited alias. To make all accounts premium by default,
+use the following commands:
+
+`sudo docker exec -it sl-db psql -U myuser simplelogin`
+
+then
+
+`ALTER TABLE users ALTER COLUMN lifetime SET DEFAULT TRUE;`
+
+make sure to create your commands **after** the changes.
 
 You don't have to pay anything to SimpleLogin to use all its features.
 You could make a donation to SimpleLogin on our Patreon page at https://www.patreon.com/simplelogin if you wish though.

--- a/README.md
+++ b/README.md
@@ -574,6 +574,25 @@ for docker-compose add this to your file:
 
 ```
 
+**note**: the words.txt volume is optional and it allows you to add your own custom words for random aliases.
+to use it make sure to create a words.txt file and type each word in each line, for example:
+
+```
+moldovanlongterm
+tremblelikable
+warpedmainsail
+opisthenarsneak
+grimahump
+chinchillastemson
+feebleperformer
+vicarchoose
+ventureinflate
+agreeablearm
+raftpelennor
+
+```
+these words will be used to create new random aliases>
+
 for docker-cli:
 
 `webapp` container:


### PR DESCRIPTION
hi, after setting up simplelogin my self, i have noticed some stuff that would be useful for new comers, so i added them into the readme file.

## top changes:
- added docker-compose examples
- added apache2 example setup
- added 'local_recipient_maps' = note in postfix
- added check for pgsql availability with `postconf -m` command
- added postgres command to make all accounts premium by default.
- added an option to add your own words for random_aliases

note the apache file is built on default-ssl.conf.