### PR TITLE
refactor(build): remove dependencies in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,16 +7,13 @@ RUN cd /code/static && npm install
 # Main image
 FROM python:3.7
 
-# install some utility packages
-RUN apt update && apt install -y vim telnet
-
 RUN pip3 install poetry==1.0.10
 
 # install dependencies
 WORKDIR /code
 COPY poetry.lock pyproject.toml ./
 RUN poetry config virtualenvs.create false \
-  && poetry install
+  && poetry install --no-root
 
 # copy npm packages
 COPY --from=npm /code /code


### PR DESCRIPTION
Remove the `vim`, `telnet` on production image

Other things to consider:

- Using smaller size Python image: python:3.7-alpine/python:3.7-slim
- Run as non-root user, ref: https://github.com/hexops/dockerfile#run-as-a-non-root-user