### PR TITLE
Export and import mailbox info with alias

### DIFF
--- a/app/api/views/export.py
+++ b/app/api/views/export.py
@@ -53,9 +53,10 @@ def export_aliases():
     """
     user = g.user
 
-    data = [["alias", "note", "enabled"]]
+    data = [["alias", "note", "enabled", "mailboxes"]]
     for alias in Alias.filter_by(user_id=user.id).all():  # type: Alias
-        data.append([alias.email, alias.note, alias.enabled])
+        mailboxes = " ".join([mailbox.email for mailbox in alias.mailboxes])
+        data.append([alias.email, alias.note, alias.enabled, mailboxes])
 
     si = StringIO()
     cw = csv.writer(si)

--- a/app/dashboard/templates/dashboard/batch_import.html
+++ b/app/dashboard/templates/dashboard/batch_import.html
@@ -10,6 +10,7 @@
       <h1 class="h3">Alias Batch Import</h1>
       <div class="alert alert-primary">
         Only aliases created with <b>your verified domains</b> can be imported.<br>
+        If mailboxes are set for an alias, they will only be linked if they already exist.<br>
         Please make sure to use the csv template file.
       </div>
 

--- a/static/batch_import_template.csv
+++ b/static/batch_import_template.csv
@@ -1,3 +1,3 @@
-"alias","note"
-"ebay@my-domain.com","Used on eBay"
-"facebook@my-domain.com","Used on Facebook, Instagram."
+"alias","note","mailboxes"
+"ebay@my-domain.com","Used on eBay","destination@my-destionation-domain.com"
+"facebook@my-domain.com","Used on Facebook, Instagram.","destination1@my-destionation-domain.com destination2@my-destination-domain.com"


### PR DESCRIPTION
I noticed while looking at everything more that the import code always uses the default mailbox. This change adds the mailboxes of each alias to the export so that the correct mailboxes can be assigned during a batch import.