### PR TITLE
Missing DKIM_PUBLIC_KEY_PATH in readme and example.env

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,8 @@ EMAIL_SERVERS_WITH_PRIORITY=[(10, "app.mydomain.com.")]
 # this option doesn't make sense in self-hosted. Set this variable to disable this option.
 DISABLE_ALIAS_SUFFIX=1
 
-# the DKIM private key used to compute DKIM-Signature
+# the DKIM public/private keys used to compute DKIM-Signature
+DKIM_PUBLIC_KEY_PATH=/dkim.pub.key
 DKIM_PRIVATE_KEY_PATH=/dkim.key
 
 # DB Connection

--- a/example.env
+++ b/example.env
@@ -69,7 +69,8 @@ EMAIL_SERVERS_WITH_PRIORITY=[(10, "email.hostname.")]
 # By default, emails are sent using the the same Postfix server that receives emails
 # POSTFIX_SERVER=my-postfix.com
 
-# the DKIM private key used to compute DKIM-Signature
+# the DKIM public/private keys used to compute DKIM-Signature
+# DKIM_PUBLIC_KEY_PATH=local_data/dkim.pub.key
 # DKIM_PRIVATE_KEY_PATH=local_data/dkim.key
 
 # delete and recreate the sqlite database, for local development


### PR DESCRIPTION
When I was trying to install and test simple-login, I had an error with my `~/simplelogin.env`.

Reading back the README and the `example.env` I discovered that one parameter was missing in both making all the script failed (like `python init_app.py`)

I hope my little PR will help some other people that was like me and didn't know why it won't init 😄 