### PR TITLE
Prefix suggestion is made more useful for .co.jp and .co.uk

### DIFF
--- a/app/api/views/alias_options.py
+++ b/app/api/views/alias_options.py
@@ -8,7 +8,7 @@ from app.dashboard.views.custom_alias import (
 from app.extensions import db
 from app.log import LOG
 from app.models import AliasUsedOn, Alias, User
-from app.utils import convert_to_id
+from app.utils import convert_to_id, suggest_prefix
 
 
 @api_bp.route("/v4/alias/options")
@@ -133,12 +133,7 @@ def options_v5():
     if hostname:
         # keep only the domain name of hostname, ignore TLD and subdomain
         # for ex www.groupon.com -> groupon
-        domain_name = hostname
-        if "." in hostname:
-            parts = hostname.split(".")
-            domain_name = parts[-2]
-            domain_name = convert_to_id(domain_name)
-        ret["prefix_suggestion"] = domain_name
+        ret["prefix_suggestion"] = suggest_prefix(hostname)
 
     suffixes = get_available_suffixes(user)
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -73,3 +73,16 @@ def sanitize_email(email_address: str) -> str:
 def query2str(query):
     """Useful utility method to print out a SQLAlchemy query"""
     return query.statement.compile(compile_kwargs={"literal_binds": True})
+
+def suggest_prefix(hostname: str) -> str:
+    suggested_prefix = hostname
+    if "." in hostname:
+        parts = hostname.split(".")
+        # useful when country uses "co.jp" or "co.uk" instead of ccTLD
+        if parts[-2] == "co":
+            suggested_prefix = parts[-3]
+        else:
+            suggested_prefix = parts[-2]
+        suggested_prefix = convert_to_id(suggested_prefix)
+
+    return suggested_prefix


### PR DESCRIPTION
When a prefix suggestion is requested for a website whose domain name looks ends in "co.jp" or "co.uk" (which is very common in Japan or the UK, the Simple login extension invariably suggests "co" as a new alias prefix.

This diff proposes to go one subdomain up when available in this case. For example, for "jprs.co.jp", it will suggest "jprs" instead of "co" currently.

I've submitted some feedback on Twitter in https://twitter.com/alung/status/1402559093592805377, ended up writing a PR ^^