### PR TITLE
Make the "Create" button focusable with keyboard

### DIFF
--- a/app/dashboard/templates/dashboard/custom_alias.html
+++ b/app/dashboard/templates/dashboard/custom_alias.html
@@ -94,7 +94,7 @@
 
         <div class="row">
           <div class="col p-1">
-            <span id="submit" class="btn btn-primary mt-1">Create</span>
+            <button type="button" id="submit" class="btn btn-primary mt-1">Create</button>
           </div>
         </div>
       </form>


### PR DESCRIPTION
Hi, I love this product and can't do without it now! Thank you for bringing me the idea of email aliases.

This PR makes the "Create" button on ["Create New Custom Alias" page](https://app.simplelogin.io/dashboard/custom_alias) focusable by a keyboard. Technically, this just replaced `<span>` with `<button type="button">`. It's not `type="submit"`, so that browsers don't natively submit.

The following figure shows what happens when I press Tab in the focused text area with the current implementation:

![before](https://user-images.githubusercontent.com/34891695/128724998-e0b49300-42bb-4db5-8724-0f32a11abd4f.jpg)


The focus jumps to the logo link.



Also, after this commit:

![after](https://user-images.githubusercontent.com/34891695/128725033-97173d4a-27c0-43c9-840a-7922cc119556.jpg)


The button is focused, and the focus ring is displayed.

