### PR TITLE
Re: Make the "Create" button focusable with keyboard

### DIFF
--- a/app/dashboard/templates/dashboard/custom_alias.html
+++ b/app/dashboard/templates/dashboard/custom_alias.html
@@ -69,7 +69,7 @@
         <div class="row mb-2">
           <div class="col p-1">
             <select data-width="100%"
-                    class="mailbox-select" id="mailboxes" multiple name="mailboxes">
+                    class="mailbox-select" id="mailboxes" multiple name="mailboxes" required>
               {% for mailbox in mailboxes %}
                 <option value="{{ mailbox.id }}" {% if mailbox.id == current_user.default_mailbox_id %}
                         selected {% endif %}>
@@ -94,7 +94,7 @@
 
         <div class="row">
           <div class="col p-1">
-            <span id="submit" class="btn btn-primary mt-1">Create</span>
+            <button type="submit" id="create" class="btn btn-primary mt-1">Create</button>
           </div>
         </div>
       </form>
@@ -117,7 +117,7 @@
       }
     })
 
-    $("#submit").on("click", async function () {
+    $("#create").on("click", async function () {
       let that = $(this);
       let mailbox_ids = $(`#mailboxes`).val();
       let prefix = $('#prefix').val();


### PR DESCRIPTION
This PR is a revised version of #561, fixes [the problem](https://github.com/simple-login/app/pull/561#issuecomment-899102494
). 

The following scenarios works well on my local machine:

1. (Error) Click the "Create" button with the prefix and mailboxes empty.
![image](https://user-images.githubusercontent.com/34891695/130111121-40a956a7-83e1-408c-90be-fb8e5cc9d07d.png)

2. (Error) Click the "Create" button with all mailboxes unchecked.
![image](https://user-images.githubusercontent.com/34891695/130111180-bc68ee1f-0350-4d9d-a3f7-4142af967383.png)

3. (Error) Click the "Create" button with the prefix empty.
![image](https://user-images.githubusercontent.com/34891695/130111457-d6f45fb9-9189-4cf2-99f0-a030d8b0ab49.png)

4. (Success) Click the "Create" button with the prefix filled and mailboxes checked.
![image](https://user-images.githubusercontent.com/34891695/130265370-173a06ba-fbe0-4be5-b73c-883b5697b06e.png)
![image](https://user-images.githubusercontent.com/34891695/130265409-d8c8c884-6000-48c8-9c18-d8b3e3cb2066.png)


---

In #561, the Create button was not working due to an error caused by Bouncer. It was saying that  "submit is not a function", which means that Bouncer couldn't  refer  to  the submit method of the form.

This was caused by the button having "submit" in its id, which is similar to [this issue](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement#issues_with_naming_elements).

So, I replaced the button's id value with "create" and prevent it from overriding  the submit method, it has got to work well.

