### PR TITLE
Create email log page

### DIFF
--- a/app/dashboard/__init__.py
+++ b/app/dashboard/__init__.py
@@ -28,4 +28,5 @@ from .views import (
     batch_import,
     alias_transfer,
     app,
+    email_log,
 )

--- a/app/dashboard/templates/dashboard/email_log.html
+++ b/app/dashboard/templates/dashboard/email_log.html
@@ -1,0 +1,73 @@
+{% extends 'default.html' %}
+
+{% set active_page = "email_log" %}
+
+{% block title %}
+  Email Log 
+{% endblock %}
+
+{% block default_content %}
+  <div class="row">
+    <div class="col">
+      <h1 class="h3"> Email Log </h1>
+      <div class="small-text">
+        All sent and forwarded messages in the last 14 days
+      </div>
+    </div>
+  </div>
+
+  <div class="row row-cards row-deck mt-4">
+    <div class="col-12">
+      <div class="card">
+        <div class="table-responsive">
+          <table class="table table-hover table-outline table-vcenter text-nowrap card-table">
+            <thead>
+            <tr>
+              <th></th>
+              <th>
+                From
+              </th>
+              <th>
+                To
+              </th>
+              <th>
+                Date
+              </th>
+              <!--<th class="text-center">Last used</th>-->
+            </tr>
+            </thead>
+            <tbody>
+            {% for email in email_log %}
+              <tr>
+                <td>
+                  {% if email.is_reply %}
+                    <i class="fa fa-reply mr-2" data-toggle="tooltip" title="Email reply/sent from alias"></i>
+                  {% elif email.bounced %}
+                    <i class="fa fa-warning mr-2" data-toggle="tooltip" title="Email bounced and cannot be forwarded to your mailbox"></i>
+                  {% elif email.blocked %}
+                    <i class="fa fa-ban mr-2 text-danger" data-toggle="tooltip" title="Email blocked"></i>
+                  {% else %}
+                    <i class="fa fa-paper-plane  mr-2" data-toggle="tooltip" title="Email sent to alias"></i>
+                  {% endif %}
+                </td>
+                <td>
+                  {{ email.contact.email }}
+                </td>
+
+                <td>
+                  {{ email.contact.alias.email }}
+                </td>
+
+                <td>
+                  {{ email.created_at | dt }}
+                </td>
+              </tr>
+            {% endfor %}
+
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/app/dashboard/views/email_log.py
+++ b/app/dashboard/views/email_log.py
@@ -1,0 +1,29 @@
+from app.db import Session
+
+"""
+List of sent and forwarded emails
+"""
+
+from flask import render_template, request, flash, redirect
+from flask_login import login_required, current_user
+from sqlalchemy.orm import joinedload
+
+from app.dashboard.base import dashboard_bp
+from app.models import (
+    EmailLog,
+)
+
+
+@dashboard_bp.route("/email_log", methods=["GET"])
+@login_required
+def email_log():
+    email_log = (
+        EmailLog.filter_by(user_id=current_user.id)
+        .order_by(EmailLog.created_at.desc())
+        .all()
+    )
+
+    return render_template(
+        "dashboard/email_log.html",
+        email_log=email_log,
+    )

--- a/templates/menu.html
+++ b/templates/menu.html
@@ -8,6 +8,15 @@
   </li>
 
   <li class="nav-item">
+    <a href="{{ url_for('dashboard.email_log') }}"
+       class="nav-link {{ 'active' if active_page == 'email_log' }}">
+      <i class="fe fe-mail"></i>
+      Email Log
+    </a>
+  </li>
+
+
+  <li class="nav-item">
     <a href="{{ url_for('dashboard.directory') }}"
        class="nav-link {{ 'active' if active_page == 'directory' }}">
       <i class="fe fe-folder"></i> Directories


### PR DESCRIPTION
I sometimes get spam and find it difficult in my mail client to see which alias is actually receiving the spam. Having the full log would be nice to have to more quickly disable the alias

I understand this probably won't scale as-is, but I first wanted to discuss this a bit before putting a lot of time into this.

My plans for this:
- [ ] Paginate (of course)
- [ ] Dropdown filter (Forwarded / Bounced / Blocked / Sent)
- [ ] Add disable/enable alias button next to each received email

Screenshot:

![image](https://user-images.githubusercontent.com/1885159/137210196-36061849-e032-4f97-9369-af503161d7b4.png)

May also be worth making the boxes on the top of the aliases screen clickable instead, to not have an extra navigation option:
![image](https://user-images.githubusercontent.com/1885159/137210768-cd9c0a7c-7017-4c9e-a055-5cb4de9a9b0e.png)
