### PR TITLE
Invalid TOTP and recovery code email notifications

### DIFF
--- a/app/api/views/auth_mfa.py
+++ b/app/api/views/auth_mfa.py
@@ -6,6 +6,7 @@ from itsdangerous import Signer
 from app.api.base import api_bp
 from app.config import FLASK_SECRET
 from app.db import Session
+from app.email_utils import send_invalid_totp_login_email
 from app.log import LOG
 from app.models import User, ApiKey
 
@@ -53,6 +54,7 @@ def auth_mfa():
 
     totp = pyotp.TOTP(user.otp_secret)
     if not totp.verify(mfa_token):
+        send_invalid_totp_login_email(user, "TOTP")
         return jsonify(error="Wrong TOTP Token"), 400
 
     ret = {"name": user.name or "", "email": user.email}

--- a/app/auth/views/mfa.py
+++ b/app/auth/views/mfa.py
@@ -16,6 +16,7 @@ from wtforms import BooleanField, StringField, validators
 from app.auth.base import auth_bp
 from app.config import MFA_USER_ID, URL
 from app.db import Session
+from app.email_utils import send_email, render
 from app.extensions import limiter
 from app.models import User, MfaBrowser
 
@@ -91,6 +92,12 @@ def mfa():
             return response
 
         else:
+            send_email(
+                user.email,
+                "There was an unsuccessful login on your SimpleLogin account",
+                render("transactional/invalid-totp-login.txt"),
+                render("transactional/invalid-totp-login.html"),
+            )
             flash("Incorrect token", "warning")
             # Trigger rate limiter
             g.deduct_limit = True

--- a/app/auth/views/mfa.py
+++ b/app/auth/views/mfa.py
@@ -92,6 +92,10 @@ def mfa():
             return response
 
         else:
+            flash("Incorrect token", "warning")
+            # Trigger rate limiter
+            g.deduct_limit = True
+            otp_token_form.token.data = None
             send_email_with_rate_control(
                 user,
                 ALERT_INVALID_TOTP_LOGIN,
@@ -107,10 +111,6 @@ def mfa():
                 ),
                 1,
             )
-            flash("Incorrect token", "warning")
-            # Trigger rate limiter
-            g.deduct_limit = True
-            otp_token_form.token.data = None
 
     return render_template(
         "auth/mfa.html",

--- a/app/auth/views/mfa.py
+++ b/app/auth/views/mfa.py
@@ -97,8 +97,14 @@ def mfa():
                 ALERT_INVALID_TOTP_LOGIN,
                 user.email,
                 "There was an unsuccessful login on your SimpleLogin account",
-                render("transactional/invalid-totp-login.txt"),
-                render("transactional/invalid-totp-login.html"),
+                render(
+                    "transactional/invalid-totp-login.txt",
+                    type="TOTP",
+                ),
+                render(
+                    "transactional/invalid-totp-login.html",
+                    type="TOTP",
+                ),
                 1,
             )
             flash("Incorrect token", "warning")

--- a/app/auth/views/mfa.py
+++ b/app/auth/views/mfa.py
@@ -14,9 +14,9 @@ from flask_wtf import FlaskForm
 from wtforms import BooleanField, StringField, validators
 
 from app.auth.base import auth_bp
-from app.config import MFA_USER_ID, URL, ALERT_INVALID_TOTP_LOGIN
+from app.config import MFA_USER_ID, URL
 from app.db import Session
-from app.email_utils import send_email_with_rate_control, render
+from app.email_utils import send_invalid_totp_login_email
 from app.extensions import limiter
 from app.models import User, MfaBrowser
 
@@ -96,21 +96,7 @@ def mfa():
             # Trigger rate limiter
             g.deduct_limit = True
             otp_token_form.token.data = None
-            send_email_with_rate_control(
-                user,
-                ALERT_INVALID_TOTP_LOGIN,
-                user.email,
-                "There was an unsuccessful login on your SimpleLogin account",
-                render(
-                    "transactional/invalid-totp-login.txt",
-                    type="TOTP",
-                ),
-                render(
-                    "transactional/invalid-totp-login.html",
-                    type="TOTP",
-                ),
-                1,
-            )
+            send_invalid_totp_login_email(user, "TOTP")
 
     return render_template(
         "auth/mfa.html",

--- a/app/auth/views/recovery.py
+++ b/app/auth/views/recovery.py
@@ -5,9 +5,9 @@ from flask_wtf import FlaskForm
 from wtforms import StringField, validators
 
 from app.auth.base import auth_bp
-from app.config import MFA_USER_ID, ALERT_INVALID_TOTP_LOGIN
+from app.config import MFA_USER_ID
 from app.db import Session
-from app.email_utils import send_email_with_rate_control, render
+from app.email_utils import send_invalid_totp_login_email
 from app.extensions import limiter
 from app.log import LOG
 from app.models import User, RecoveryCode
@@ -69,20 +69,6 @@ def recovery_route():
             # Trigger rate limiter
             g.deduct_limit = True
             flash("Incorrect code", "error")
-            send_email_with_rate_control(
-                user,
-                ALERT_INVALID_TOTP_LOGIN,
-                user.email,
-                "There was an unsuccessful login on your SimpleLogin account",
-                render(
-                    "transactional/invalid-totp-login.txt",
-                    type="recovery",
-                ),
-                render(
-                    "transactional/invalid-totp-login.html",
-                    type="recovery",
-                ),
-                1,
-            )
+            send_invalid_totp_login_email(user, "recovery")
 
     return render_template("auth/recovery.html", recovery_form=recovery_form)

--- a/app/auth/views/recovery.py
+++ b/app/auth/views/recovery.py
@@ -68,6 +68,7 @@ def recovery_route():
         else:
             # Trigger rate limiter
             g.deduct_limit = True
+            flash("Incorrect code", "error")
             send_email_with_rate_control(
                 user,
                 ALERT_INVALID_TOTP_LOGIN,
@@ -83,6 +84,5 @@ def recovery_route():
                 ),
                 1,
             )
-            flash("Incorrect code", "error")
 
     return render_template("auth/recovery.html", recovery_form=recovery_form)

--- a/app/config.py
+++ b/app/config.py
@@ -321,6 +321,8 @@ ALERT_FROM_ADDRESS_IS_REVERSE_ALIAS = "from_address_is_reverse_alias"
 
 ALERT_SPF = "spf"
 
+ALERT_INVALID_TOTP_LOGIN = "invalid_totp_login"
+
 # when a mailbox is also an alias
 # happens when user adds a mailbox with their domain
 # then later adds this domain into SimpleLogin

--- a/app/email_utils.py
+++ b/app/email_utils.py
@@ -179,7 +179,7 @@ def send_invalid_totp_login_email(user, totp_type):
         user,
         ALERT_INVALID_TOTP_LOGIN,
         user.email,
-        "There was an unsuccessful login on your SimpleLogin account",
+        "Unsuccessful attempt to login to your SimpleLogin account",
         render(
             "transactional/invalid-totp-login.txt",
             type=totp_type,

--- a/app/email_utils.py
+++ b/app/email_utils.py
@@ -50,6 +50,7 @@ from app.config import (
     ALERT_DIRECTORY_DISABLED_ALIAS_CREATION,
     TRANSACTIONAL_BOUNCE_EMAIL,
     ALERT_SPF,
+    ALERT_INVALID_TOTP_LOGIN,
     TEMP_DIR,
     ALIAS_AUTOMATIC_DISABLE,
     RSPAMD_SIGN_DKIM,
@@ -170,6 +171,24 @@ def send_change_email(new_email, current_email, link):
             new_email=new_email,
             current_email=current_email,
         ),
+    )
+
+
+def send_invalid_totp_login_email(user, totp_type):
+    send_email_with_rate_control(
+        user,
+        ALERT_INVALID_TOTP_LOGIN,
+        user.email,
+        "There was an unsuccessful login on your SimpleLogin account",
+        render(
+            "transactional/invalid-totp-login.txt",
+            type=totp_type,
+        ),
+        render(
+            "transactional/invalid-totp-login.html",
+            type=totp_type,
+        ),
+        1,
     )
 
 

--- a/templates/dashboard/setting.html
+++ b/templates/dashboard/setting.html
@@ -209,7 +209,7 @@
     <!-- END Change email -->
 
     <!-- Change password -->
-    <div class="card">
+    <div class="card" id="change_password">
       <div class="card-body">
         <div class="card-title">
           Password

--- a/templates/emails/transactional/invalid-totp-login.html
+++ b/templates/emails/transactional/invalid-totp-login.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+  {{ render_text("There has been an unsuccessful login on your SimpleLogin account.") }}
+  {{ render_text("An invalid TOTP code was provided. <b>The email and password were provided correctly.</b>") }}
+
+  {{ render_text("If this was <b>not</b> you, please <b>change your password immediately.</b>") }}
+  {{ render_text('Thanks, <br />SimpleLogin Team.') }}
+{% endblock %}
+

--- a/templates/emails/transactional/invalid-totp-login.html
+++ b/templates/emails/transactional/invalid-totp-login.html
@@ -2,7 +2,7 @@
 
 {% block content %}
   {{ render_text("There has been an unsuccessful login attempt on your SimpleLogin account.") }}
-  {{ render_text("An invalid TOTP code was provided <b>but the email and password were provided correctly.</b>") }}
+  {{ render_text("An invalid " ~ type ~ " code was provided <b>but the email and password were provided correctly.</b>") }}
 
   {{ render_text("This request was blocked. However, if this was <b>not</b> you, please <b>change your password immediately.</b>") }}
   {{ render_button("Change your password", URL ~ "/dashboard/setting#change_password") }}

--- a/templates/emails/transactional/invalid-totp-login.html
+++ b/templates/emails/transactional/invalid-totp-login.html
@@ -2,9 +2,11 @@
 
 {% block content %}
   {{ render_text("There has been an unsuccessful login attempt on your SimpleLogin account.") }}
-  {{ render_text("An invalid TOTP code was provided. <b>The email and password were provided correctly.</b>") }}
+  {{ render_text("An invalid TOTP code was provided <b>but the email and password were provided correctly.</b>") }}
 
   {{ render_text("This request was blocked. However, if this was <b>not</b> you, please <b>change your password immediately.</b>") }}
-  {{ render_text('Thanks, <br />SimpleLogin Team.') }}
-{% endblock %}
+  {{ render_button("Change your password", URL ~ "/dashboard/setting#change_password") }}
 
+  {{ render_text('Thanks, <br />SimpleLogin Team.') }}
+  {{ raw_url(URL ~ "/dashboard/setting#change_password") }}
+{% endblock %}

--- a/templates/emails/transactional/invalid-totp-login.html
+++ b/templates/emails/transactional/invalid-totp-login.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 
 {% block content %}
-  {{ render_text("There has been an unsuccessful login attempt on your SimpleLogin account.") }}
-  {{ render_text("An invalid " ~ type ~ " code was provided <b>but the email and password were provided correctly.</b>") }}
+  {{ render_text("There has been an unsuccessful attempt to login to your SimpleLogin account.") }}
+  {{ render_text("An invalid " ~ type ~ " code was provided <b>but the email and password were correct.</b>") }}
 
-  {{ render_text("This request was blocked. However, if this was <b>not</b> you, please <b>change your password immediately.</b>") }}
+  {{ render_text("This request has been blocked. However, if this was <b>not</b> you, please <b>change your password immediately.</b>") }}
   {{ render_button("Change your password", URL ~ "/dashboard/setting#change_password") }}
 
   {{ render_text('Thanks, <br />SimpleLogin Team.') }}

--- a/templates/emails/transactional/invalid-totp-login.html
+++ b/templates/emails/transactional/invalid-totp-login.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 
 {% block content %}
-  {{ render_text("There has been an unsuccessful login on your SimpleLogin account.") }}
+  {{ render_text("There has been an unsuccessful login attempt on your SimpleLogin account.") }}
   {{ render_text("An invalid TOTP code was provided. <b>The email and password were provided correctly.</b>") }}
 
-  {{ render_text("If this was <b>not</b> you, please <b>change your password immediately.</b>") }}
+  {{ render_text("This request was blocked. However, if this was <b>not</b> you, please <b>change your password immediately.</b>") }}
   {{ render_text('Thanks, <br />SimpleLogin Team.') }}
 {% endblock %}
 

--- a/templates/emails/transactional/invalid-totp-login.txt
+++ b/templates/emails/transactional/invalid-totp-login.txt
@@ -1,5 +1,5 @@
 There has been an unsuccessful login attempt on your SimpleLogin account.
-An invalid TOTP code was provided but the email and password were provided correctly.
+An invalid {{type}} code was provided but the email and password were provided correctly.
 
 This request was blocked. However, if this was not you, please change your password immediately.
 {{URL}}/dashboard/setting#change_password

--- a/templates/emails/transactional/invalid-totp-login.txt
+++ b/templates/emails/transactional/invalid-totp-login.txt
@@ -1,7 +1,8 @@
 There has been an unsuccessful login attempt on your SimpleLogin account.
-An invalid TOTP code was provided. The email and password were provided correctly.
+An invalid TOTP code was provided but the email and password were provided correctly.
 
-This request was blocked. However, if this was not you, please <b>change your password immediately.
+This request was blocked. However, if this was not you, please change your password immediately.
+{{URL}}/dashboard/setting#change_password
 
 Thanks,
 SimpleLogin Team.

--- a/templates/emails/transactional/invalid-totp-login.txt
+++ b/templates/emails/transactional/invalid-totp-login.txt
@@ -1,7 +1,7 @@
-There has been an unsuccessful login attempt on your SimpleLogin account.
-An invalid {{type}} code was provided but the email and password were provided correctly.
+There has been an unsuccessful attempt to login to your SimpleLogin account.
+An invalid {{type}} code was provided but the email and password were correct.
 
-This request was blocked. However, if this was not you, please change your password immediately.
+This request has been blocked. However, if this was not you, please change your password immediately.
 {{URL}}/dashboard/setting#change_password
 
 Thanks,

--- a/templates/emails/transactional/invalid-totp-login.txt
+++ b/templates/emails/transactional/invalid-totp-login.txt
@@ -1,0 +1,7 @@
+There has been an unsuccessful login on your SimpleLogin account.
+An invalid TOTP code was provided. The email and password were provided correctly.
+
+If this was not you, please <b>change your password immediately.
+
+Thanks,
+SimpleLogin Team.

--- a/templates/emails/transactional/invalid-totp-login.txt
+++ b/templates/emails/transactional/invalid-totp-login.txt
@@ -1,7 +1,7 @@
-There has been an unsuccessful login on your SimpleLogin account.
+There has been an unsuccessful login attempt on your SimpleLogin account.
 An invalid TOTP code was provided. The email and password were provided correctly.
 
-If this was not you, please <b>change your password immediately.
+This request was blocked. However, if this was not you, please <b>change your password immediately.
 
 Thanks,
 SimpleLogin Team.


### PR DESCRIPTION
This PR adds notifications for invalid TOTP codes where the user has correctly entered their email and password.

This is what the email currently looks like:
![image](https://user-images.githubusercontent.com/23139726/150357049-9da89a42-25a8-4566-b983-bb49f3fb96e9.png)

This is just a draft though as we obviously do not want to send an email every time this happens, we'd need to implement some kind of rate limit (maybe 1 email per day). I'm wondering if send_email_with_rate_control is the best way to achieve this?