### PR TITLE
Add a button to delete all API Keys

### DIFF
--- a/app/dashboard/views/api_key.py
+++ b/app/dashboard/views/api_key.py
@@ -41,17 +41,18 @@ def api_key():
             Session.commit()
             flash(f"API Key {name} has been deleted", "success")
 
-            return redirect(url_for("dashboard.api_key"))
-
         elif request.form.get("form-name") == "create":
             if new_api_key_form.validate():
                 new_api_key = ApiKey.create(
                     name=new_api_key_form.name.data, user_id=current_user.id
                 )
                 Session.commit()
-
                 flash(f"New API Key {new_api_key.name} has been created", "success")
-                return redirect(url_for("dashboard.api_key"))
+
+        elif request.form.get("form-name") == "delete-all":
+            ApiKey.deleteall(current_user.id)
+            Session.commit()
+            flash("All API Keys have been deleted", "success")
 
         return redirect(url_for("dashboard.api_key"))
 

--- a/app/models.py
+++ b/app/models.py
@@ -1966,6 +1966,10 @@ class ApiKey(Base, ModelMixin):
 
         return super().create(user_id=user_id, name=name, code=code, **kwargs)
 
+    @classmethod
+    def deleteall(cls, user_id):
+        Session.query(cls).filter(cls.user_id == user_id).delete()
+
 
 class CustomDomain(Base, ModelMixin):
     __tablename__ = "custom_domain"

--- a/templates/dashboard/api_key.html
+++ b/templates/dashboard/api_key.html
@@ -22,6 +22,16 @@
         ️API Keys should be kept secret and treated like passwords, they can be used to gain access to your account.
       </div>
 
+      {% if api_keys|length > 0 %}
+      <form method="post">
+        <input type="hidden" name="form-name" value="delete-all">
+          <span class="delete btn btn-danger delete-all-api-keys">
+              Delete All &nbsp; &nbsp; <i class="fe fe-trash"></i>
+          </span>
+      </form>
+      <br>
+      {% endif %}
+
       <div class="row">
         {% for api_key in api_keys %}
           <div class="col-12 col-lg-6">
@@ -116,6 +126,31 @@
           }
         }
       })
+
+
+    });
+
+    $(".delete-all-api-keys").on("click", function (e) {
+        let that = $(this);
+
+        bootbox.confirm({
+            message: "This will delete all API Keys, they will all stop working, are you sure?",
+            buttons: {
+                confirm: {
+                    label: 'Delete All',
+                    className: 'btn-danger'
+                },
+                cancel: {
+                    label: 'Cancel',
+                    className: 'btn-outline-primary'
+                }
+            },
+            callback: function (result) {
+                if (result) {
+                    that.closest("form").submit();
+                }
+            }
+        })
 
 
     });


### PR DESCRIPTION
This PR adds a button to delete all API Keys.
![image](https://user-images.githubusercontent.com/23139726/150692967-13b458bc-a60e-456b-9f5a-802e5724b405.png)
