### PR TITLE
Add the user's name to TOTP invalid login email notifications.

### DIFF
--- a/app/email_utils.py
+++ b/app/email_utils.py
@@ -181,7 +181,7 @@ def send_invalid_totp_login_email(user, totp_type):
         user.email,
         "Unsuccessful attempt to login to your SimpleLogin account",
         render(
-            "transactional/invalid-totp-login.txt",
+            "transactional/invalid-totp-login.txt.jinja2",
             name=user.name,
             type=totp_type,
         ),

--- a/app/email_utils.py
+++ b/app/email_utils.py
@@ -182,13 +182,13 @@ def send_invalid_totp_login_email(user, totp_type):
         "Unsuccessful attempt to login to your SimpleLogin account",
         render(
             "transactional/invalid-totp-login.txt",
+            name=user.name,
             type=totp_type,
-            name=user.name
         ),
         render(
             "transactional/invalid-totp-login.html",
+            name=user.name,
             type=totp_type,
-            name=user.name
         ),
         1,
     )

--- a/app/email_utils.py
+++ b/app/email_utils.py
@@ -183,10 +183,12 @@ def send_invalid_totp_login_email(user, totp_type):
         render(
             "transactional/invalid-totp-login.txt",
             type=totp_type,
+            name=user.name
         ),
         render(
             "transactional/invalid-totp-login.html",
             type=totp_type,
+            name=user.name
         ),
         1,
     )

--- a/templates/emails/transactional/invalid-totp-login.html
+++ b/templates/emails/transactional/invalid-totp-login.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-  {{ render_text("Hello, " ~ name ~ ",") }}
+  {{ render_text("Hello," ~ (" " ~ name ~ "," if name)) }}
   {{ render_text("There has been an unsuccessful attempt to login to your SimpleLogin account.") }}
   {{ render_text("An invalid " ~ type ~ " code was provided <b>but the email and password were correct.</b>") }}
 

--- a/templates/emails/transactional/invalid-totp-login.html
+++ b/templates/emails/transactional/invalid-totp-login.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
+  {{ render_text("Hello, " ~ name ~ ",") }}
   {{ render_text("There has been an unsuccessful attempt to login to your SimpleLogin account.") }}
   {{ render_text("An invalid " ~ type ~ " code was provided <b>but the email and password were correct.</b>") }}
 

--- a/templates/emails/transactional/invalid-totp-login.txt
+++ b/templates/emails/transactional/invalid-totp-login.txt
@@ -1,3 +1,5 @@
+Hello, {{name}},
+
 There has been an unsuccessful attempt to login to your SimpleLogin account.
 An invalid {{type}} code was provided but the email and password were correct.
 

--- a/templates/emails/transactional/invalid-totp-login.txt.jinja2
+++ b/templates/emails/transactional/invalid-totp-login.txt.jinja2
@@ -1,4 +1,4 @@
-Hello, {{name}},
+Hello,{{" " ~ name ~ "," if name}}
 
 There has been an unsuccessful attempt to login to your SimpleLogin account.
 An invalid {{type}} code was provided but the email and password were correct.


### PR DESCRIPTION
This PR adds the user's name to the TOTP invalid login email notifications (#753) (see [this comment](https://github.com/simple-login/app/pull/753#issuecomment-1022096915) for more details)