### PR TITLE
Fix deprecation warnings.

### DIFF
--- a/app/dns_utils.py
+++ b/app/dns_utils.py
@@ -23,7 +23,7 @@ def get_ns(hostname) -> [str]:
 def get_cname_record(hostname) -> Optional[str]:
     """Return the CNAME record if exists for a domain, WITHOUT the trailing period at the end"""
     try:
-        answers = _get_dns_resolver().query(hostname, "CNAME")
+        answers = _get_dns_resolver().resolve(hostname, "CNAME")
     except Exception:
         return None
 
@@ -39,7 +39,7 @@ def get_mx_domains(hostname) -> [(int, str)]:
     domain name ends with a "." at the end.
     """
     try:
-        answers = _get_dns_resolver().query(hostname, "MX")
+        answers = _get_dns_resolver().resolve(hostname, "MX")
     except Exception:
         return []
 
@@ -60,7 +60,7 @@ _include_spf = "include:"
 def get_spf_domain(hostname) -> [str]:
     """return all domains listed in *include:*"""
     try:
-        answers = _get_dns_resolver().query(hostname, "TXT")
+        answers = _get_dns_resolver().resolve(hostname, "TXT")
     except Exception:
         return []
 
@@ -82,7 +82,7 @@ def get_spf_domain(hostname) -> [str]:
 def get_txt_record(hostname) -> [str]:
     """return all domains listed in *include:*"""
     try:
-        answers = _get_dns_resolver().query(hostname, "TXT")
+        answers = _get_dns_resolver().resolve(hostname, "TXT")
     except Exception:
         return []
 

--- a/tests/api/test_alias.py
+++ b/tests/api/test_alias.py
@@ -1,5 +1,3 @@
-from deprecated import deprecated
-
 from flask import url_for
 
 from app.config import PAGE_LIMIT
@@ -9,7 +7,6 @@ from app.models import User, ApiKey, Alias, Contact, EmailLog, Mailbox
 from tests.utils import login
 
 
-@deprecated
 def test_get_aliases_error_without_pagination(flask_client):
     user = User.create(
         email="a@b.c",
@@ -31,7 +28,6 @@ def test_get_aliases_error_without_pagination(flask_client):
     assert r.json["error"]
 
 
-@deprecated
 def test_get_aliases_with_pagination(flask_client):
     user = User.create(
         email="a@b.c",
@@ -79,7 +75,6 @@ def test_get_aliases_with_pagination(flask_client):
     assert len(r.json["aliases"]) == 2
 
 
-@deprecated
 def test_get_aliases_query(flask_client):
     user = User.create(
         email="a@b.c", password="password", name="Test User", activated=True


### PR DESCRIPTION
This PR uses resolve() instead of query() to resolve DNS queries. It also removes the deprecation tag from tests, I don't see any point in deprecating a test? Is there a valid reason for this @nguyenkims?