### PR TITLE
Add required package for authentication with AWS SES

### DIFF
--- a/docs/ses.md
+++ b/docs/ses.md
@@ -51,6 +51,12 @@ For Ubuntu, we point postfix to the CA Certs;
 sudo postconf -e 'smtp_tls_CAfile = /etc/ssl/certs/ca-certificates.crt'
 ```
 
+Also make sure that Postfix is able to authenticate successfully by installing the SASL package:
+
+```bash
+sudo apt install libsasl2-modules
+```
+
 Then restart postfix 
 
 ```bash


### PR DESCRIPTION
One of the issues I was having when setting up SimpleLogin was this missing package in my Ubuntu 20 installation. Took me quite some time to figure out where the issue was, so I figured it'd be good to include it in the instructions.