### PR TITLE
Run parsley validation on page reload.

### DIFF
--- a/templates/dashboard/custom_alias.html
+++ b/templates/dashboard/custom_alias.html
@@ -113,11 +113,17 @@
     $('.mailbox-select').multipleSelect();
 
     // Ctrl-enter submit the form
-    $('form').keydown(function (event) {
+    let form = $('form');
+    form.keydown(function (event) {
       if (event.ctrlKey && event.keyCode === 13) {
         $("#submit").click();
       }
     })
+    if ("getEntriesByType" in performance) {
+        if (performance.getEntriesByType("navigation").find(nav => nav.type === 'reload')) {
+            form.parsley().validate();
+        }
+    }
 
     $("#create").on("click", async function () {
       let that = $(this);

--- a/templates/dashboard/domain_detail/auto-create.html
+++ b/templates/dashboard/domain_detail/auto-create.html
@@ -164,8 +164,11 @@
 {% block script %}
   <script>
     $('.mailbox-select').multipleSelect();
-
-
+    if ("getEntriesByType" in performance) {
+        if (performance.getEntriesByType("navigation").find(nav => nav.type === 'reload')) {
+            $('form').parsley().validate();
+        }
+    }
   </script>
 {% endblock %}
 

--- a/templates/dashboard/subdomain.html
+++ b/templates/dashboard/subdomain.html
@@ -137,5 +137,10 @@
         }
       }
     });
+    if ("getEntriesByType" in performance) {
+        if (performance.getEntriesByType("navigation").find(nav => nav.type === 'reload')) {
+            $('form').parsley().validate();
+        }
+    }
   </script>
 {% endblock %}

--- a/templates/oauth/authorize.html
+++ b/templates/oauth/authorize.html
@@ -199,3 +199,12 @@
     </div>
   </form>
 {% endblock %}
+{% block script %}
+<script>
+    if ("getEntriesByType" in performance) {
+        if (performance.getEntriesByType("navigation").find(nav => nav.type === 'reload')) {
+            $('form').parsley().validate();
+        }
+    }
+</script>
+{% endblock %}


### PR DESCRIPTION
Currently if you input some bad data into a form with parsley validation and refresh the page, the bad data is not outlined:
![image](https://user-images.githubusercontent.com/23139726/154368289-6b6bc234-c2ab-4545-867b-a6460c83c117.png)

This PR rechecks parsley validation on page reload using the `PerformanceNavigationTiming.type` property. See [compatibility table](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming/type#browser_compatibility). Now on page reload, the user is shown current validation status:
![image](https://user-images.githubusercontent.com/23139726/154368539-74659e68-095f-4e38-b019-0ce31fae3ca4.png)