### PR TITLE
Improve notification

### DIFF
--- a/app/dashboard/views/notification.py
+++ b/app/dashboard/views/notification.py
@@ -23,6 +23,10 @@ def notification_route(notification_id):
         )
         return redirect(url_for("dashboard.index"))
 
+    if not notification.read:
+        notification.read = True
+        Session.commit()
+
     if request.method == "POST":
         notification_title = notification.title or notification.message[:20]
         Notification.delete(notification_id)

--- a/email_handler.py
+++ b/email_handler.py
@@ -1401,7 +1401,6 @@ def handle_bounce_forward_phase(msg: Message, email_log: EmailLog):
             f"Disable alias {alias} because {reason}. {alias.mailboxes} {alias.user}. Last contact {contact}"
         )
         alias.enabled = False
-        Session.commit()
 
         Notification.create(
             user_id=user.id,
@@ -1409,8 +1408,9 @@ def handle_bounce_forward_phase(msg: Message, email_log: EmailLog):
             message=Notification.render(
                 "notification/alias-disable.html", alias=alias, mailbox=mailbox
             ),
-            commit=True,
         )
+
+        Session.commit()
 
         send_email_with_rate_control(
             user,

--- a/email_handler.py
+++ b/email_handler.py
@@ -1403,6 +1403,15 @@ def handle_bounce_forward_phase(msg: Message, email_log: EmailLog):
         alias.enabled = False
         Session.commit()
 
+        Notification.create(
+            user_id=user.id,
+            title=f"{alias.email} has been disabled due to multiple bounces",
+            message=Notification.render(
+                "notification/alias-disable.html", alias=alias, mailbox=mailbox
+            ),
+            commit=True,
+        )
+
         send_email_with_rate_control(
             user,
             ALERT_BOUNCE_EMAIL,

--- a/templates/header.html
+++ b/templates/header.html
@@ -38,15 +38,13 @@
 
             <div class="dropdown-item d-flex" v-for="notification in notifications">
               <div class="flex-grow-1">
-                <div v-html="notification.title" class="font-weight-bold"
+
+                <div v-html="notification.title || notification.message"
+                     :class="!notification.read && 'font-weight-bold'"
                      style="width: 40em; word-wrap:break-word; white-space: normal; overflow: hidden;"></div>
 
 
-                <div v-html="notification.message"
-                     style="width: 40em; word-wrap:break-word; white-space: normal; overflow: hidden; max-height: 100px; text-overflow: ellipsis;">
-                </div>
-
-                <div>
+                <div v-if="notification.title">
                   <a :href="'/dashboard/notification/' + notification.id">More</a>
                 </div>
 

--- a/templates/notification/alias-disable.html
+++ b/templates/notification/alias-disable.html
@@ -1,0 +1,10 @@
+<div>
+  There are several emails sent to your alias <b>{{ alias.email }}</b> that have been bounced by your
+  mailbox <b>{{ mailbox.email }}</b>.
+</div>
+
+<div>
+  As security measure, we have disabled the alias <b>{{ alias.email }}</b>.
+
+</div>
+


### PR DESCRIPTION
- mark a notification as read when user arrives on the notification page
- create a notification when an alias is disabled
- show "more" only when a notification has a title. 
- Show either notification title or message. 
- Use bold font when a notification isn't read