### PR TITLE
Reduce backscatter by checking return-path domain SPF status

### DIFF
--- a/app/email/status.py
+++ b/app/email/status.py
@@ -21,6 +21,7 @@ E212 = "250 SL E212 Bounce Reply phase handled"
 E213 = "250 SL E213 Unknown email ignored"
 E214 = "250 SL E214 Unauthorized for using reverse alias"
 E215 = "250 SL E215 Handled dmarc policy"
+E216 = "250 SL E216 Handled spf policy"
 
 # endregion
 

--- a/app/models.py
+++ b/app/models.py
@@ -3,7 +3,7 @@ import os
 import random
 import uuid
 from email.utils import formataddr
-from typing import List, Tuple, Optional
+from typing import List, Tuple, Optional, Dict
 
 import arrow
 import sqlalchemy as sa
@@ -263,7 +263,7 @@ class SPFCheckResult(EnumE):
     soft_fail = 1
     neutral = 2
     temp_error = 3
-    none = 4
+    not_available = 4
     perm_error = 5
 
     @staticmethod
@@ -274,9 +274,25 @@ class SPFCheckResult(EnumE):
             "R_SPF_SOFTFAIL": SPFCheckResult.soft_fail,
             "R_SPF_NEUTRAL": SPFCheckResult.neutral,
             "R_SPF_DNSFAIL": SPFCheckResult.temp_error,
-            "R_SPF_NA": SPFCheckResult.none,
+            "R_SPF_NA": SPFCheckResult.not_available,
             "R_SPF_PERMFAIL": SPFCheckResult.perm_error,
         }
+
+
+class SpamdResult:
+    def __init__(self):
+        self.dmarc: DmarcCheckResult = DmarcCheckResult.not_available
+        self.spf: SPFCheckResult = SPFCheckResult.not_available
+        self.domain = "unknown"
+
+    def set_dmarc_result(self, dmarc_result: DmarcCheckResult):
+        self.dmarc = dmarc_result
+
+    def set_spf_result(self, spf_result: SPFCheckResult):
+        self.spf = spf_result
+
+    def event_data(self) -> Dict:
+        return {"header": "present", "dmarc": self.dmarc, "spf": self.spf}
 
 
 class Hibp(Base, ModelMixin):

--- a/app/models.py
+++ b/app/models.py
@@ -283,7 +283,6 @@ class SpamdResult:
     def __init__(self):
         self.dmarc: DmarcCheckResult = DmarcCheckResult.not_available
         self.spf: SPFCheckResult = SPFCheckResult.not_available
-        self.domain = "unknown"
 
     def set_dmarc_result(self, dmarc_result: DmarcCheckResult):
         self.dmarc = dmarc_result

--- a/app/models.py
+++ b/app/models.py
@@ -257,6 +257,28 @@ class DmarcCheckResult(EnumE):
         }
 
 
+class SPFCheckResult(EnumE):
+    allow = 0
+    fail = 1
+    soft_fail = 1
+    neutral = 2
+    temp_error = 3
+    none = 4
+    perm_error = 5
+
+    @staticmethod
+    def get_string_dict():
+        return {
+            "R_SPF_ALLOW": SPFCheckResult.allow,
+            "R_SPF_FAIL": SPFCheckResult.fail,
+            "R_SPF_SOFTFAIL": SPFCheckResult.soft_fail,
+            "R_SPF_NEUTRAL": SPFCheckResult.neutral,
+            "R_SPF_DNSFAIL": SPFCheckResult.temp_error,
+            "R_SPF_NA": SPFCheckResult.none,
+            "R_SPF_PERMFAIL": SPFCheckResult.perm_error,
+        }
+
+
 class Hibp(Base, ModelMixin):
     __tablename__ = "hibp"
     name = sa.Column(sa.String(), nullable=False, unique=True, index=True)

--- a/email_handler.py
+++ b/email_handler.py
@@ -563,7 +563,7 @@ def apply_dmarc_policy(
         # DmarcCheckResult.soft_fail,
     ):
         LOG.w(
-            f"put email from {contact} to {alias} to quarantine. {spam_result}, "
+            f"put email from {contact} to {alias} to quarantine. {spam_result.event_data()}, "
             f"mail_from:{envelope.mail_from}, from_header: {msg[headers.FROM]}"
         )
         email_log = quarantine_dmarc_failed_email(alias, contact, envelope, msg)
@@ -2595,7 +2595,8 @@ class MailHandler:
             return_status = handle(envelope, msg)
             elapsed = time.time() - start
             if return_status[0] == "5":
-                if get_spamd_result(msg).spf in (
+                spamd_result = get_spamd_result(msg)
+                if spamd_result and get_spamd_result(msg).spf in (
                     SPFCheckResult.fail,
                     SPFCheckResult.soft_fail,
                 ):

--- a/email_handler.py
+++ b/email_handler.py
@@ -2601,10 +2601,11 @@ class MailHandler:
             elapsed = time.time() - start
 
             LOG.i(
-                "Finish mail_from %s, rcpt_tos %s, takes %s seconds <<===",
+                "Finish mail_from %s, rcpt_tos %s, takes %s seconds with return code '%s'<<===",
                 envelope.mail_from,
                 envelope.rcpt_tos,
                 elapsed,
+                ret,
             )
             newrelic.agent.record_custom_metric("Custom/email_handler_time", elapsed)
             newrelic.agent.record_custom_metric("Custom/number_incoming_email", 1)

--- a/email_handler.py
+++ b/email_handler.py
@@ -2594,6 +2594,7 @@ class MailHandler:
         with create_light_app().app_context():
             return_status = handle(envelope, msg)
             elapsed = time.time() - start
+            # Only bounce messages if the return-path passes the spf check. Otherwise black-hole it.
             if return_status[0] == "5":
                 spamd_result = get_spamd_result(msg)
                 if spamd_result and get_spamd_result(msg).spf in (

--- a/tests/example_emls/5xx_overwrite_spf.eml
+++ b/tests/example_emls/5xx_overwrite_spf.eml
@@ -1,0 +1,28 @@
+X-SimpleLogin-Client-IP: 54.39.200.130
+Received-SPF: Softfail (mailfrom) identity=mailfrom; client-ip=34.59.200.130;
+ helo=relay.somewhere.net; envelope-from=everwaste@gmail.com;
+ receiver=<UNKNOWN>
+Received: from relay.somewhere.net (relay.somewhere.net [34.59.200.130])
+        (using TLSv1.2 with cipher ECDHE-RSA-AES256-GCM-SHA384 (256/256 bits))
+        (No client certificate requested)
+        by mx1.sldev.ovh (Postfix) with ESMTPS id 6D8C13F069
+        for <wehrman_mannequin@sldev.ovh>; Thu, 17 Mar 2022 16:50:20 +0000 (UTC)
+Date: Thu, 17 Mar 2022 16:50:18 +0000
+To: {{ alias_email }}
+From: somewhere@rainbow.com
+Subject: test Thu, 17 Mar 2022 16:50:18 +0000
+Message-Id: <20220317165018.000191@somewhere-5488dd4b6b-7crp6>
+X-Mailer: swaks v20201014.0 jetmore.org/john/code/swaks/
+X-Rspamd-Queue-Id: 6D8C13F069
+X-Rspamd-Server: staging1
+X-Spamd-Result: default: False [0.50 / 13.00];
+        MID_RHS_NOT_FQDN(0.50)[];
+        DMARC_NA(0.10);
+        MIME_GOOD(-0.10)[text/plain];
+        MIME_TRACE(0.00)[0:+];
+        TO_DN_NONE(0.00)[];
+        {{ spf_result }}(0.00[];
+        TO_MATCH_ENVRCPT_ALL(0.00)[];
+        ARC_NA(0.00)[]
+
+This is a test mailing

--- a/tests/example_emls/no_spamd_header.eml
+++ b/tests/example_emls/no_spamd_header.eml
@@ -1,0 +1,19 @@
+X-SimpleLogin-Client-IP: 54.39.200.130
+Received-SPF: Softfail (mailfrom) identity=mailfrom; client-ip=34.59.200.130;
+ helo=relay.somewhere.net; envelope-from=everwaste@gmail.com;
+ receiver=<UNKNOWN>
+Received: from relay.somewhere.net (relay.somewhere.net [34.59.200.130])
+        (using TLSv1.2 with cipher ECDHE-RSA-AES256-GCM-SHA384 (256/256 bits))
+        (No client certificate requested)
+        by mx1.sldev.ovh (Postfix) with ESMTPS id 6D8C13F069
+        for <wehrman_mannequin@sldev.ovh>; Thu, 17 Mar 2022 16:50:20 +0000 (UTC)
+Date: Thu, 17 Mar 2022 16:50:18 +0000
+To: {{ alias_email }}
+From: somewhere@rainbow.com
+Subject: test Thu, 17 Mar 2022 16:50:18 +0000
+Message-Id: <20220317165018.000191@somewhere-5488dd4b6b-7crp6>
+X-Mailer: swaks v20201014.0 jetmore.org/john/code/swaks/
+X-Rspamd-Queue-Id: 6D8C13F069
+X-Rspamd-Server: staging1
+
+This is a test mailing

--- a/tests/test_email_handler.py
+++ b/tests/test_email_handler.py
@@ -145,3 +145,17 @@ def test_preserve_5xx_with_valid_spf(flask_client):
     envelope.rcpt_tos = [msg["to"]]
     result = email_handler.MailHandler()._handle(envelope, msg)
     assert result == status.E512
+
+
+def test_preserve_5xx_with_no_header(flask_client):
+    user = create_random_user()
+    alias = Alias.create_new_random(user)
+    msg = load_eml_file(
+        "no_spamd_header.eml",
+        {"alias_email": alias.email},
+    )
+    envelope = Envelope()
+    envelope.mail_from = BOUNCE_EMAIL.format(999999999999999999)
+    envelope.rcpt_tos = [msg["to"]]
+    result = email_handler.MailHandler()._handle(envelope, msg)
+    assert result == status.E512

--- a/tests/test_email_utils.py
+++ b/tests/test_email_utils.py
@@ -36,7 +36,7 @@ from app.email_utils import (
     get_orig_message_from_bounce,
     get_mailbox_bounce_info,
     is_invalid_mailbox_domain,
-    get_dmarc_status,
+    get_spamd_result,
 )
 from app.models import (
     User,
@@ -797,29 +797,29 @@ def test_is_invalid_mailbox_domain(flask_client):
 
 def test_dmarc_result_softfail():
     msg = load_eml_file("dmarc_gmail_softfail.eml")
-    assert DmarcCheckResult.soft_fail == get_dmarc_status(msg)
+    assert DmarcCheckResult.soft_fail == get_spamd_result(msg).dmarc
 
 
 def test_dmarc_result_quarantine():
     msg = load_eml_file("dmarc_quarantine.eml")
-    assert DmarcCheckResult.quarantine == get_dmarc_status(msg)
+    assert DmarcCheckResult.quarantine == get_spamd_result(msg).dmarc
 
 
 def test_dmarc_result_reject():
     msg = load_eml_file("dmarc_reject.eml")
-    assert DmarcCheckResult.reject == get_dmarc_status(msg)
+    assert DmarcCheckResult.reject == get_spamd_result(msg).dmarc
 
 
 def test_dmarc_result_allow():
     msg = load_eml_file("dmarc_allow.eml")
-    assert DmarcCheckResult.allow == get_dmarc_status(msg)
+    assert DmarcCheckResult.allow == get_spamd_result(msg).dmarc
 
 
 def test_dmarc_result_na():
     msg = load_eml_file("dmarc_na.eml")
-    assert DmarcCheckResult.not_available == get_dmarc_status(msg)
+    assert DmarcCheckResult.not_available == get_spamd_result(msg).dmarc
 
 
 def test_dmarc_result_bad_policy():
     msg = load_eml_file("dmarc_bad_policy.eml")
-    assert DmarcCheckResult.bad_policy == get_dmarc_status(msg)
+    assert DmarcCheckResult.bad_policy == get_spamd_result(msg).dmarc


### PR DESCRIPTION
Mute 5XX return codes with 2XX codes when return-path domain fails SPF checks