### PR TITLE
Save original envelope for debugging

### DIFF
--- a/app/email_utils.py
+++ b/app/email_utils.py
@@ -6,6 +6,9 @@ import random
 import time
 import uuid
 from copy import deepcopy
+
+from aiosmtpd.smtp import Envelope
+
 from email import policy, message_from_bytes, message_from_string
 from email.header import decode_header, Header
 from email.message import Message, EmailMessage
@@ -1432,12 +1435,30 @@ def save_email_for_debugging(msg: Message, file_name_prefix=None) -> str:
     if TEMP_DIR:
         file_name = str(uuid.uuid4()) + ".eml"
         if file_name_prefix:
-            file_name = file_name_prefix + file_name
+            file_name = "{}-{}".format(file_name_prefix, file_name)
 
         with open(os.path.join(TEMP_DIR, file_name), "wb") as f:
             f.write(msg.as_bytes())
 
         LOG.d("email saved to %s", file_name)
+        return file_name
+
+    return ""
+
+
+def save_envelope_for_debugging(envelope: Envelope, file_name_prefix=None) -> str:
+    """Save envelope for debugging to temporary location
+    Return the file path
+    """
+    if TEMP_DIR:
+        file_name = str(uuid.uuid4()) + ".eml"
+        if file_name_prefix:
+            file_name = "{}-{}".format(file_name_prefix, file_name)
+
+        with open(os.path.join(TEMP_DIR, file_name), "wb") as f:
+            f.write(envelope.original_content)
+
+        LOG.d("envelope saved to %s", file_name)
         return file_name
 
     return ""

--- a/email_handler.py
+++ b/email_handler.py
@@ -131,6 +131,7 @@ from app.email_utils import (
     get_mailbox_bounce_info,
     save_email_for_debugging,
     get_spamd_result,
+    save_envelope_for_debugging,
 )
 from app.errors import (
     NonReverseAliasInReplyPhase,
@@ -2584,8 +2585,8 @@ class MailHandler:
                 envelope.rcpt_tos,
                 msg[headers.FROM],
                 msg[headers.TO],
-                save_email_for_debugging(
-                    msg, file_name_prefix=e.__class__.__name__
+                save_envelope_for_debugging(
+                    envelope, file_name_prefix=e.__class__.__name__
                 ),  # todo: remove
             )
             return status.E404


### PR DESCRIPTION
Instead of saving the modified email save the original envelope so we can try to reproduce the problem easily