### PR TITLE
Only send enum name for events intead of the full class.enum

### DIFF
--- a/app/events/auth_event.py
+++ b/app/events/auth_event.py
@@ -20,7 +20,7 @@ class LoginEvent:
 
     def send(self):
         newrelic.agent.record_custom_event(
-            "LoginEvent", {"action": self.action, "source": self.source}
+            "LoginEvent", {"action": self.action.name, "source": self.source.name}
         )
 
 
@@ -42,5 +42,5 @@ class RegisterEvent:
 
     def send(self):
         newrelic.agent.record_custom_event(
-            "RegisterEvent", {"action": self.action, "source": self.source}
+            "RegisterEvent", {"action": self.action.name, "source": self.source.name}
         )


### PR DESCRIPTION
So in new relic we'll see `action=login` instead of `action=RegisterEvent.Action.login`