### PR TITLE
Calculate proper padding when decoding base32

### DIFF
--- a/app/email_utils.py
+++ b/app/email_utils.py
@@ -1497,9 +1497,9 @@ def get_verp_info_from_email(email: str) -> Optional[Tuple[VerpType, int]]:
     fields = username.split(".")
     if len(fields) != 3 or fields[0] != VERP_PREFIX:
         return None
-    padding = 8 - (len(fields[1]) % 8)
+    padding = (8 - (len(fields[1]) % 8)) % 8
     payload = base64.b32decode(fields[1].encode("utf-8").upper() + (b"=" * padding))
-    padding = 8 - (len(fields[2]) % 8)
+    padding = (8 - (len(fields[2]) % 8)) % 8
     signature = base64.b32decode(fields[2].encode("utf-8").upper() + (b"=" * padding))
     expected_signature = hmac.new(
         VERP_EMAIL_SECRET.encode("utf-8"), payload, "shake128"

--- a/tests/test_email_utils.py
+++ b/tests/test_email_utils.py
@@ -770,12 +770,14 @@ def test_is_invalid_mailbox_domain(flask_client):
     assert not is_invalid_mailbox_domain("xy.zt")
 
 
-def test_generate_verp_email():
-    generated_email = generate_verp_email(VerpType.bounce_forward, 1, "somewhere.net")
-    print(generated_email)
+@pytest.mark.parametrize("object_id", [10**i for i in range(0, 5)])
+def test_generate_verp_email(object_id):
+    generated_email = generate_verp_email(
+        VerpType.bounce_forward, object_id, "somewhere.net"
+    )
     info = get_verp_info_from_email(generated_email.lower())
     assert info[0] == VerpType.bounce_forward
-    assert info[1] == 1
+    assert info[1] == object_id
 
 
 def test_add_header_multipart_with_invalid_part():


### PR DESCRIPTION
Added missing `% 8` to the padding calculator and ensured in the tests that we're testing all possible paddings.