### PR TITLE
Allow SimpleLogin to be used as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ authors = ["SimpleLogin <dev@simplelogin.io>"]
 license = "MIT"
 repository = "https://github.com/simple-login/app"
 keywords = ["email", "alias", "privacy", "oauth2", "openid"]
+packages = [
+  { include = "app/" }
+]
 
 [tool.poetry.dependencies]
 python = "^3.7"


### PR DESCRIPTION
This PR adds an attribute to the `pyproject.toml` file that allows simplelogin to be included as a dependency from other Python projects.