### PR TITLE
Do not send the transports to the js part since we have not stored them previously

### DIFF
--- a/app/auth/views/fido.py
+++ b/app/auth/views/fido.py
@@ -155,7 +155,8 @@ def fido():
     webauthn_assertion_options = webauthn_assertion_options.assertion_dict
     try:
         # HACK: We need to upgrade to webauthn > 1 so it can support specifying the transports
-        del webauthn_assertion_options["allowCredentials"][0]["transports"]
+        for credential in webauthn_assertion_options["allowCredentials"]:
+            del credential["transports"]
     except KeyError:
         # Should never happen but...
         pass

--- a/app/auth/views/fido.py
+++ b/app/auth/views/fido.py
@@ -153,6 +153,12 @@ def fido():
         webauthn_users, challenge
     )
     webauthn_assertion_options = webauthn_assertion_options.assertion_dict
+    try:
+        # HACK: We need to upgrade to webauthn > 1 so it can support specifying the transports
+        del webauthn_assertion_options["allowCredentials"][0]["transports"]
+    except KeyError:
+        # Should never happen but...
+        pass
 
     return render_template(
         "auth/fido.html",


### PR DESCRIPTION
Closes #929 

Cable is still not accepted in the webauthn spec but safari and crhome implement it. We can just remove the requirement since we don't know what's the proper transport for each credential because we're not saving it on creation.