### PR TITLE
Update SSL documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,8 +515,7 @@ Reload Nginx with the command below
 sudo systemctl reload nginx
 ```
 
-At this step, you should also setup the SSL for Nginx. 
-[Certbot](https://certbot.eff.org/instructions) can be a good option if you want a free SSL certificate.
+At this step, you should also setup the SSL for Nginx. [Here's our guide how](./docs/ssl.md).
 
 ### Enjoy!
 

--- a/docs/ssl.md
+++ b/docs/ssl.md
@@ -1,27 +1,22 @@
-It's highly recommended to enable SSL/TLS on your server, both for the webapp and email server.
+# SSL, HTTPS, and HSTS
 
-This doc will use https://letsencrypt.org to get a free SSL certificate for app.mydomain.com that's used by both Postfix and Nginx. Letsencrypt provides Certbot, a tool to obtain and renew SSL certificates.
+It's highly recommended to enable SSL/TLS on your server, both for the web app and email server.
+
+## Using Certbot to get a certificate
+
+This doc will use https://letsencrypt.org to get a free SSL certificate for app.mydomain.com that's used by both Postfix and Nginx. Let's Encrypt provides Certbot, a tool to obtain and renew SSL certificates.
 
 To install Certbot, please follow instructions on https://certbot.eff.org
 
-As of today (March 25 2020), you can install Certbot by using these commands:
-
-```bash
-sudo apt-get update
-sudo apt-get install software-properties-common
-sudo add-apt-repository universe
-sudo add-apt-repository ppa:certbot/certbot
-sudo apt-get update
-sudo apt-get install certbot python-certbot-nginx
-``` 
-
-Then obtain a certificate for Nginx, use the following command. You'd need to provide an email so Letsencrypt can send you notifications when your domain is about to expire.
+Then obtain a certificate for Nginx, use the following command. You'd need to provide an email so Let's Encrypt can send you notifications when your domain is about to expire.
 
 ```bash
 sudo certbot --nginx
 ```
 
-After this step, you should see some Certbot lines in /etc/nginx/sites-enabled/simplelogin
+After this step, you should see some "managed by Certbot" lines in `/etc/nginx/sites-enabled/simplelogin`
+
+### Securing Postfix
 
 Now let's use the new certificate for our Postfix.
 
@@ -32,11 +27,34 @@ smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
 smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
 ```
 
-by 
+with 
 
 ```
 smtpd_tls_cert_file = /etc/letsencrypt/live/app.mydomain.com/fullchain.pem
 smtpd_tls_key_file = /etc/letsencrypt/live/app.mydomain.com/privkey.pem
 ``` 
 
-Make sure to replace app.mydomain.com by your domain. 
+Make sure to replace app.mydomain.com with your own domain.
+
+### Updating `simplelogin.env`
+
+Make sure to change the `URL` in `simplelogin.env` to `https://app.mydomain.com`, otherwise not all page assets will load securely, and some functionality (e.g. Webauthn) will break.
+You will need to reload the docker containers for this to take effect.
+
+## HTTP Strict Transport Security (HSTS)
+
+HSTS is an extra step you can take to protect your web app from certain man-in-the-middle attacks. It does this by specifying an amount of time (usually a really long one) for which you should only accept HTTPS connections, not HTTP ones. Because of this **you should only enable HSTS once you know HTTPS is working correctly**, as otherwise you may find your browser blocking you from accessing your own web app.
+
+To enable HSTS, add the following line to the `server` block of the Nginx configuration file:
+
+```
+add_header Strict-Transport-Security "max-age: 31536000; includeSubDomains" always;
+```
+
+(The `max-age` is the time in seconds to not permit a HTTP connection, in this case it's one year.)
+
+Now, reload Nginx:
+
+```bash
+sudo systemctl reload nginx
+```


### PR DESCRIPTION
If merged, this PR will:
- Improve readability of `docs/ssl.md`
- Adds a section on HSTS
- Link to SSL doc in README at the relevant point
- Removes outdated certbot installation technique which is no longer supported

Mitigates the likelihood of users (like me!) [footgunning themselves](https://github.com/simple-login/app/discussions/600)

Thanks @developStorm for helping identify the cause of my issue!

The only thing I'm not 100% confident with is which container instances need to be restarted for `simplelogin.env` changes to be fully propogated. I can tighten the phrasing if someone can confirm for me :)