### PR TITLE
Preserve next_url in oauth login

### DIFF
--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -45,7 +45,7 @@
       </form>
       {% if connect_with_proton %}
         <div class="text-center my-2 text-gray"><span>or</span></div>
-        <a class="btn btn-primary btn-block mt-2 proton-button" href="{{ url_for("auth.proton_login") }}">Log in with Proton</a>
+        <a class="btn btn-primary btn-block mt-2 proton-button" href="{{ url_for("auth.proton_login", next=next_url) }}">Log in with Proton</a>
       {% endif %}
     </div>
 


### PR DESCRIPTION
This PR allows the "Login with Proton" feature to preserve the `next` parameter so the user is redirected after a successful login.