### PR TITLE
GH Actions refactor

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Run tests & Publish to Docker Registry
 on: [push, pull_request]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
@@ -93,8 +93,13 @@ jobs:
           name: code-coverage-report
           path: htmlcov
 
+  build:
+    runs-on: ubuntu-latest
+    needs: ['test']
+
+    steps:
       - name: Publish to Docker Registry
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
         uses: docker/build-push-action@v1
         with:
           repository: simplelogin/app-ci
@@ -103,7 +108,7 @@ jobs:
           tag_with_ref: true
 
       - name: Create Sentry release
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
         uses: getsentry/action-release@v1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,6 +120,10 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
 
+      # We need to checkout the repository in order for the "Create Sentry release" to work
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
       - name: Create Sentry release
         uses: getsentry/action-release@v1
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 name: Run tests & Publish to Docker Registry
 
-on: [push, pull_request]
+on: 
+  push:
+  pull_request:
+    types: [ 'opened' ]
 
 jobs:
   test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,13 +102,23 @@ jobs:
     if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
 
     steps:
-      - name: Publish to Docker Registry
-        uses: docker/build-push-action@v1
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
         with:
-          repository: simplelogin/app-ci
+          images: simplelogin/app-ci
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          tag_with_ref: true
+
+      - name: Build image and publish to Docker Registry
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
 
       - name: Create Sentry release
         uses: getsentry/action-release@v1
@@ -123,3 +133,11 @@ jobs:
           to: ${{ secrets.TELEGRAM_TO }}
           token: ${{ secrets.TELEGRAM_TOKEN }}
           args: Docker image pushed on ${{ github.ref }}
+
+      - name: Post notification to Slack
+        uses: slackapi/slack-github-action@v1.19.0
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack-message: "New tag generated: ${{github.ref}}\nBuild result: ${{ job.status }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,10 +99,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: ['test']
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
 
     steps:
       - name: Publish to Docker Registry
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
         uses: docker/build-push-action@v1
         with:
           repository: simplelogin/app-ci
@@ -111,7 +111,6 @@ jobs:
           tag_with_ref: true
 
       - name: Create Sentry release
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
         uses: getsentry/action-release@v1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -119,7 +118,6 @@ jobs:
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
 
       - name: Send Telegram message
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: appleboy/telegram-action@master
         with:
           to: ${{ secrets.TELEGRAM_TO }}


### PR DESCRIPTION
- Create docker container also on tag
- Only run the docker container creation once 
- Run the workflow on push and on PR creation so it's run only once when the PR is updated with new commits