### PR TITLE
Fix: Track processes that start with the same chars independently (smtp vs stmpd)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-xaddopts =
+addopts =
     --cov
     --cov-config coverage.ini
     --cov-report=html:htmlcov

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts =
+xaddopts =
     --cov
     --cov-config coverage.ini
     --cov-report=html:htmlcov

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -8,7 +8,8 @@ def test_monitoring_proc_count():
    3438 ?        Ssl    0:00 /bin/sh arg
    3440 ?        Sl     0:00 /bin/cron args
    3440 ?        Sl     0:00 smtp arg
-   3440 ?        Sl     0:00 smtpd arg
+   3448 ?        Sl     0:00 smtpd arg
+   3441 ?        Sl     0:00 other smtpd arg
     """
     result = _process_ps_output(["smtp", "smtpd", "cron"], data)
     assert 1 == result["smtp"]

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,0 +1,16 @@
+from monitoring import get_num_procs, _process_ps_output
+
+
+def test_monitoring_proc_count():
+    data = """
+    PID TTY      STAT   TIME COMMAND
+   1432 ?        S<     0:00 [loop44]
+   3438 ?        Ssl    0:00 /bin/sh arg
+   3440 ?        Sl     0:00 /bin/cron args
+   3440 ?        Sl     0:00 smtp arg
+   3440 ?        Sl     0:00 smtpd arg
+    """
+    result = _process_ps_output(["smtp", "smtpd", "cron"], data)
+    assert 1 == result["smtp"]
+    assert 1 == result["smtpd"]
+    assert 0 == result["cron"]

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,4 +1,4 @@
-from monitoring import get_num_procs, _process_ps_output
+from monitoring import _process_ps_output
 
 
 def test_monitoring_proc_count():


### PR DESCRIPTION
Before `smtp` and `smtpd` both counted as the same since they started with the same chars.