### PR TITLE
Added TOTP-like alias generation and included some extra information on CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,9 +64,10 @@ Install npm packages
 cd static && npm install
 ```
 
-To run the code locally, please create a local setting file based on `example.env`:
+To run the code locally, go back to the root folder, and please create a local setting file based on `example.env`:
 
 ```
+cd ..
 cp example.env .env
 ```
 

--- a/app/api/views/new_random_alias.py
+++ b/app/api/views/new_random_alias.py
@@ -98,8 +98,10 @@ def new_random_alias():
                 scheme = AliasGeneratorEnum.word.value
             elif mode == "uuid":
                 scheme = AliasGeneratorEnum.uuid.value
+            elif mode == "totp":
+                scheme = AliasGeneratorEnum.totp.value
             else:
-                return jsonify(error=f"{mode} must be either word or uuid"), 400
+                return jsonify(error=f"{mode} must be either word, uuid, or totp"), 400
 
         alias = Alias.create_new_random(user=user, scheme=scheme, note=note)
         Session.commit()

--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,7 @@
 import enum
 import os
 import random
+import string
 import uuid
 from email.utils import formataddr
 from typing import List, Tuple, Optional
@@ -216,6 +217,7 @@ class SenderFormatEnum(EnumE):
 class AliasGeneratorEnum(EnumE):
     word = 1  # aliases are generated based on random words
     uuid = 2  # aliases are generated based on uuid
+    totp = 3  # aliases are generated based on random characters
 
 
 class AliasSuffixEnum(EnumE):
@@ -1188,8 +1190,11 @@ def generate_email(
     if scheme == AliasGeneratorEnum.uuid.value:
         name = uuid.uuid4().hex if in_hex else uuid.uuid4().__str__()
         random_email = name + "@" + alias_domain
-    else:
+    elif scheme == AliasGeneratorEnum.word.value:
         random_email = random_words() + "@" + alias_domain
+    else:
+        name = "".join(random.choices(string.digits + string.ascii_lowercase, k=6))
+        random_email = name + "@" + alias_domain
 
     random_email = random_email.lower().strip()
 

--- a/templates/dashboard/setting.html
+++ b/templates/dashboard/setting.html
@@ -266,6 +266,9 @@
             <option value="{{ AliasGeneratorEnum.uuid.value }}"
                 {% if current_user.alias_generator == AliasGeneratorEnum.uuid.value %} selected {% endif %} >Based
               on {{ AliasGeneratorEnum.uuid.name.upper() }}</option>
+            <option value="{{ AliasGeneratorEnum.totp.value }}"
+                {% if current_user.alias_generator == AliasGeneratorEnum.totp.value %} selected {% endif %} >Based
+              on {{ AliasGeneratorEnum.totp.name.upper() }}</option>
           </select>
           <button class="btn btn-outline-primary">Update</button>
         </form>


### PR DESCRIPTION
I like having short aliases, but UUIDs are very long, and I prefer using random characters instead of two random words, so I constantly find myself creating custom aliases like:

```
abw7iy@domain.tld
```

This pull request adds a mode that allows creating random aliases just like that one, which is very similar to the code we might get when using one-time-passwords.

I also modified `CONTRIBUTING.md` and explained that to copy the `example.env`, we first have to go back to the root folder. I spent a minute trying to find out why I could not copy that file 😅

Please do let me know if there is anything else I need to do before this can be merged 😊