### PR TITLE
redirect user to dashboard instead of the account activation page for now

### DIFF
--- a/app/auth/views/activate.py
+++ b/app/auth/views/activate.py
@@ -64,4 +64,6 @@ def activate():
         return redirect(next_url)
     else:
         LOG.d("redirect user to dashboard")
-        return redirect(url_for("onboarding.account_activated"))
+        return redirect(url_for("dashboard.index"))
+        # todo: redirect to account_activated page when more features are added into the browser extension
+        # return redirect(url_for("onboarding.account_activated"))


### PR DESCRIPTION
As the browser extension still lacks a lot of features and we invite user to install the browser extension in the onboarding email, let's redirect user to the dashboard instead of the account activation page for now. We can re-enable the account activation page when the extension is more complete/