### PR TITLE
Store hmaced partner api tokens

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -465,3 +465,6 @@ def setup_nameservers():
 NAMESERVERS = setup_nameservers()
 
 DISABLE_CREATE_CONTACTS_FOR_FREE_USERS = False
+PARTNER_API_TOKEN_SECRET = os.environ.get("PARTNER_API_TOKEN_SECRET") or (
+    FLASK_SECRET + "partnerapitoken"
+)

--- a/app/models.py
+++ b/app/models.py
@@ -3095,9 +3095,10 @@ class Partner(Base, ModelMixin):
             )
             .first()
         )
-        if res is None or res.Partner is None:
-            return None
-        return res.Partner
+        if res:
+            partner, partner_api_token = res
+            return partner
+        return None
 
 
 class PartnerApiToken(Base, ModelMixin):

--- a/example.env
+++ b/example.env
@@ -186,3 +186,4 @@ ALLOWED_REDIRECT_DOMAINS=[]
 # DNS nameservers to be used by the app
 # Multiple nameservers can be specified, separated by ','
 NAMESERVERS="1.1.1.1"
+PARTNER_API_TOKEN_SECRET="changeme"

--- a/migrations/versions/2022_052516_2b1d3cd93e4b_update_partner_api_token_token_length.py
+++ b/migrations/versions/2022_052516_2b1d3cd93e4b_update_partner_api_token_token_length.py
@@ -1,0 +1,30 @@
+"""update partner_api_token token length
+
+Revision ID: 2b1d3cd93e4b
+Revises: 088f23324464
+Create Date: 2022-05-25 16:43:33.017076
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '2b1d3cd93e4b'
+down_revision = '088f23324464'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('partner_api_token', 'token',
+                    existing_type=sa.String(length=32),
+                    type_=sa.String(length=50),
+                    nullable=False)
+
+
+def downgrade():
+    op.alter_column('partner_api_token', 'token',
+                    existing_type=sa.String(length=50),
+                    type_=sa.String(length=32),
+                    nullable=False)

--- a/tests/models/test_partner_api_token.py
+++ b/tests/models/test_partner_api_token.py
@@ -9,7 +9,7 @@ def test_generate_partner_api_token(flask_client):
         commit=True,
     )
 
-    (partner_api_token, token) = PartnerApiToken.generate(partner.id, None)
+    partner_api_token, token = PartnerApiToken.generate(partner.id, None)
 
     assert token is not None
     assert len(token) > 0

--- a/tests/models/test_partner_api_token.py
+++ b/tests/models/test_partner_api_token.py
@@ -1,0 +1,25 @@
+from app.models import Partner, PartnerApiToken
+from app.utils import random_string
+
+
+def test_generate_partner_api_token(flask_client):
+    partner = Partner.create(
+        name=random_string(10),
+        contact_email="{s}@{s}.com".format(s=random_string(10)),
+        commit=True,
+    )
+
+    (partner_api_token, token) = PartnerApiToken.generate(partner.id, None)
+
+    assert token is not None
+    assert len(token) > 0
+
+    assert partner_api_token.partner_id == partner.id
+    assert partner_api_token.expiration_time is None
+
+    hmaced = PartnerApiToken.hmac_token(token)
+    assert hmaced == partner_api_token.token
+
+    retrieved_partner = Partner.find_by_token(token)
+    assert retrieved_partner is not None
+    assert retrieved_partner.id == partner.id


### PR DESCRIPTION
This PR performs the following changes:

1. Add a migration for increasing the size of partner api tokens
2. Add a `PartnerApiToken.generate` method that takes care of generating api tokens, processing them and storing them into the database
3. Add a `Partner.find_by_token` method that allows retrieving a `Partner` instance given a raw `PartnerApiToken`.