### PR TITLE
Do not report complaints for deleted aliases

### DIFF
--- a/app/handler/provider_complaint.py
+++ b/app/handler/provider_complaint.py
@@ -295,9 +295,9 @@ def report_complaint_to_user_in_transactional_phase(
 def report_complaint_to_user_in_forward_phase(
     alias: Alias, origin: ProviderComplaintOrigin, msg_info: OriginalMessageInformation
 ):
+    capitalized_name = origin.name().capitalize()
     user = alias.user
     mailbox_email = msg_info.mailbox_address or alias.mailbox.email
-    capitalized_name = origin.name().capitalize()
     send_email_with_rate_control(
         user,
         f"{ALERT_COMPLAINT_FORWARD_PHASE}_{origin.name()}",

--- a/app/models.py
+++ b/app/models.py
@@ -2232,6 +2232,7 @@ class DomainDeletedAlias(Base, ModelMixin):
     user_id = sa.Column(sa.ForeignKey(User.id, ondelete="cascade"), nullable=False)
 
     domain = orm.relationship(CustomDomain)
+    user = orm.relationship(User, foreign_keys=[user_id])
 
     @classmethod
     def create(cls, **kw):


### PR DESCRIPTION
- In the case of deleted aliases, we no longer have the user so skip reporting the complaint back to the user
- For domain deleted ones, use the user orm relationship