### PR TITLE
Add extension_redirect endpoint

### DIFF
--- a/app/onboarding/__init__.py
+++ b/app/onboarding/__init__.py
@@ -3,4 +3,5 @@ from .views import (
     final,
     setup_done,
     account_activated,
+    extension_redirect,
 )

--- a/app/onboarding/utils.py
+++ b/app/onboarding/utils.py
@@ -1,0 +1,64 @@
+from dataclasses import dataclass
+from enum import Enum
+from flask import request
+from typing import Optional
+
+CHROME_EXTENSION_LINK = "https://chrome.google.com/webstore/detail/simpleloginreceive-send-e/dphilobhebphkdjbpfohgikllaljmgbn"
+FIREFOX_EXTENSION_LINK = "https://addons.mozilla.org/firefox/addon/simplelogin/"
+EDGE_EXTENSION_LINK = "https://microsoftedge.microsoft.com/addons/detail/simpleloginreceive-sen/diacfpipniklenphgljfkmhinphjlfff"
+
+
+@dataclass
+class ExtensionInfo:
+    browser: str
+    url: str
+
+
+class Browser(Enum):
+    Firefox = 1
+    Chrome = 2
+    Edge = 3
+    Other = 4
+
+
+def is_mobile() -> bool:
+    return request.user_agent.platform in [
+        "android",
+        "blackberry",
+        "ipad",
+        "iphone",
+        "symbian",
+    ]
+
+
+def get_browser() -> Browser:
+    if is_mobile():
+        return Browser.Other
+
+    user_agent = request.user_agent
+    if user_agent.browser == "edge":
+        return Browser.Edge
+    elif user_agent.browser in ["chrome", "opera", "webkit"]:
+        return Browser.Chrome
+    elif user_agent.browser in ["mozilla", "firefox"]:
+        return Browser.Firefox
+    return Browser.Other
+
+
+def get_extension_info() -> Optional[ExtensionInfo]:
+    browser = get_browser()
+    if browser == Browser.Chrome:
+        extension_link = CHROME_EXTENSION_LINK
+        browser_name = "Chrome"
+    elif browser == Browser.Firefox:
+        extension_link = FIREFOX_EXTENSION_LINK
+        browser_name = "Firefox"
+    elif browser == Browser.Edge:
+        extension_link = EDGE_EXTENSION_LINK
+        browser_name = "Edge"
+    else:
+        return None
+    return ExtensionInfo(
+        browser=browser_name,
+        url=extension_link,
+    )

--- a/app/onboarding/views/account_activated.py
+++ b/app/onboarding/views/account_activated.py
@@ -1,63 +1,18 @@
 from app.onboarding.base import onboarding_bp
-from enum import Enum
-from flask import redirect, render_template, request, url_for
+from app.onboarding.utils import get_extension_info
+from flask import redirect, render_template, url_for
 from flask_login import login_required
-
-
-CHROME_EXTENSION_LINK = "https://chrome.google.com/webstore/detail/simpleloginreceive-send-e/dphilobhebphkdjbpfohgikllaljmgbn"
-FIREFOX_EXTENSION_LINK = "https://addons.mozilla.org/firefox/addon/simplelogin/"
-EDGE_EXTENSION_LINK = "https://microsoftedge.microsoft.com/addons/detail/simpleloginreceive-sen/diacfpipniklenphgljfkmhinphjlfff"
-
-
-class Browser(Enum):
-    Firefox = 1
-    Chrome = 2
-    Edge = 3
-    Other = 4
-
-
-def is_mobile() -> bool:
-    return request.user_agent.platform in [
-        "android",
-        "blackberry",
-        "ipad",
-        "iphone",
-        "symbian",
-    ]
-
-
-def get_browser() -> Browser:
-    if is_mobile():
-        return Browser.Other
-
-    user_agent = request.user_agent
-    if user_agent.browser == "edge":
-        return Browser.Edge
-    elif user_agent.browser in ["chrome", "opera", "webkit"]:
-        return Browser.Chrome
-    elif user_agent.browser in ["mozilla", "firefox"]:
-        return Browser.Firefox
-    return Browser.Other
 
 
 @onboarding_bp.route("/account_activated", methods=["GET"])
 @login_required
 def account_activated():
-    browser = get_browser()
-    if browser == Browser.Chrome:
-        extension_link = CHROME_EXTENSION_LINK
-        browser_name = "Chrome"
-    elif browser == Browser.Firefox:
-        extension_link = FIREFOX_EXTENSION_LINK
-        browser_name = "Firefox"
-    elif browser == Browser.Edge:
-        extension_link = EDGE_EXTENSION_LINK
-        browser_name = "Edge"
-    else:
+    info = get_extension_info()
+    if not info:
         return redirect(url_for("dashboard.index"))
 
     return render_template(
         "onboarding/account_activated.html",
-        extension_link=extension_link,
-        browser_name=browser_name,
+        extension_link=info.url,
+        browser_name=info.browser,
     )

--- a/app/onboarding/views/extension_redirect.py
+++ b/app/onboarding/views/extension_redirect.py
@@ -1,0 +1,11 @@
+from app.onboarding.base import onboarding_bp
+from app.onboarding.utils import get_extension_info
+from flask import redirect, url_for
+
+
+@onboarding_bp.route("/extension_redirect", methods=["GET"])
+def extension_redirect():
+    info = get_extension_info()
+    if not info:
+        return redirect(url_for("dashboard.index"))
+    return redirect(info.url)

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,0 +1,15 @@
+from http import HTTPStatus
+from app.onboarding.utils import CHROME_EXTENSION_LINK
+
+
+CHROME_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36"
+
+
+def test_extension_redirect_is_working(flask_client):
+    res = flask_client.get(
+        "/onboarding/extension_redirect", headers={"User-Agent": CHROME_USER_AGENT}
+    )
+    assert res.status_code == HTTPStatus.FOUND
+
+    location_header = res.headers.get("Location")
+    assert location_header == CHROME_EXTENSION_LINK


### PR DESCRIPTION
This PR adds the following changes:

* Move the browser detection and extension links to a `app/onboarding/utils.py` file
* a `GET /onboarding/extension_redirect` endpoint that redirects the user to the extension link depending on their browser