### PR TITLE
Allow to create users from partner

### DIFF
--- a/app/account_linking.py
+++ b/app/account_linking.py
@@ -29,6 +29,7 @@ class PartnerLinkRequest:
     email: str
     external_user_id: str
     plan: SLPlan
+    from_partner: bool
 
 
 @dataclass
@@ -121,6 +122,7 @@ class NewUserStrategy(ClientMergeStrategy):
             email=self.link_request.email,
             name=self.link_request.name,
             password=random_string(20),
+            from_partner=self.link_request.from_partner,
         )
         partner_user = PartnerUser.create(
             user_id=new_user.id,

--- a/app/account_linking.py
+++ b/app/account_linking.py
@@ -147,7 +147,7 @@ class NewUserStrategy(ClientMergeStrategy):
         )
 
 
-class ExistingUnlinedUserStrategy(ClientMergeStrategy):
+class ExistingUnlinkedUserStrategy(ClientMergeStrategy):
     def process(self) -> LinkResult:
 
         partner_user = ensure_partner_user_exists_for_user(
@@ -177,7 +177,7 @@ def get_login_strategy(
     if other_partner_user is not None:
         return LinkedWithAnotherPartnerUserStrategy(link_request, user, partner)
     # There is a SimpleLogin user with the partner_user's e-mail
-    return ExistingUnlinedUserStrategy(link_request, user, partner)
+    return ExistingUnlinkedUserStrategy(link_request, user, partner)
 
 
 def process_login_case(

--- a/app/proton/proton_callback_handler.py
+++ b/app/proton/proton_callback_handler.py
@@ -113,6 +113,7 @@ class ProtonCallbackHandler:
             external_user_id=proton_user.id,
             name=proton_user.name,
             plan=proton_user.plan,
+            from_partner=False,  # The user has started this flow, so we don't mark it as created by a partner
         )
 
     def __get_proton_user(self) -> Optional[ProtonUser]:

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -1,7 +1,17 @@
-from tests.utils import create_new_user
+from app.models import User
+from tests.utils import create_new_user, random_email
 
 
 def test_available_sl_domains(flask_client):
     user = create_new_user()
 
     assert set(user.available_sl_domains()) == {"d1.test", "d2.test", "sl.local"}
+
+
+def test_create_from_partner(flask_client):
+    user = User.create(email=random_email(), from_partner=True)
+    assert User.FLAG_CREATED_FROM_PARTNER == (
+        user.flags & User.FLAG_CREATED_FROM_PARTNER
+    )
+    assert user.notification is False
+    assert user.trial_end is None

--- a/tests/proton/test_proton_callback_handler.py
+++ b/tests/proton/test_proton_callback_handler.py
@@ -44,6 +44,12 @@ def test_proton_callback_handler_unexistant_sl_user():
     assert res.user is not None
     assert res.user.email == email
     assert res.user.name == name
+    # Ensure the user is not marked as created from partner
+    assert User.FLAG_CREATED_FROM_PARTNER != (
+        res.user.flags & User.FLAG_CREATED_FROM_PARTNER
+    )
+    assert res.user.notification is True
+    assert res.user.trial_end is not None
 
     partner_user = PartnerUser.get_by(
         partner_id=get_proton_partner().id, user_id=res.user.id
@@ -68,6 +74,12 @@ def test_proton_callback_handler_existant_sl_user():
 
     assert res.user is not None
     assert res.user.id == sl_user.id
+    # Ensure the user is not marked as created from partner
+    assert User.FLAG_CREATED_FROM_PARTNER != (
+        res.user.flags & User.FLAG_CREATED_FROM_PARTNER
+    )
+    assert res.user.notification is True
+    assert res.user.trial_end is not None
 
     sa = PartnerUser.get_by(user_id=sl_user.id, partner_id=get_proton_partner().id)
     assert sa is not None

--- a/tests/test_account_linking.py
+++ b/tests/test_account_linking.py
@@ -77,10 +77,9 @@ def test_get_strategy_unexistant_sl_user():
 
 def test_login_case_from_partner():
     partner = get_proton_partner()
-    external_user_id = random_string()
     res = process_login_case(
         random_link_request(
-            external_user_id=external_user_id,
+            external_user_id=random_string(),
             from_partner=True,
         ),
         partner,
@@ -91,13 +90,13 @@ def test_login_case_from_partner():
     assert User.FLAG_CREATED_FROM_PARTNER == (
         res.user.flags & User.FLAG_CREATED_FROM_PARTNER
     )
-    
+
+
 def test_login_case_from_web():
     partner = get_proton_partner()
-    external_user_id = random_string()
     res = process_login_case(
         random_link_request(
-            external_user_id=external_user_id,
+            external_user_id=random_string(),
             from_partner=False,
         ),
         partner,
@@ -105,9 +104,7 @@ def test_login_case_from_web():
 
     assert res.strategy == NewUserStrategy.__name__
     assert res.user is not None
-    assert 0 == (
-        res.user.flags & User.FLAG_CREATED_FROM_PARTNER
-    )
+    assert 0 == (res.user.flags & User.FLAG_CREATED_FROM_PARTNER)
 
 
 def test_get_strategy_existing_sl_user():

--- a/tests/test_account_linking.py
+++ b/tests/test_account_linking.py
@@ -91,6 +91,23 @@ def test_login_case_from_partner():
     assert User.FLAG_CREATED_FROM_PARTNER == (
         res.user.flags & User.FLAG_CREATED_FROM_PARTNER
     )
+    
+def test_login_case_from_web():
+    partner = get_proton_partner()
+    external_user_id = random_string()
+    res = process_login_case(
+        random_link_request(
+            external_user_id=external_user_id,
+            from_partner=False,
+        ),
+        partner,
+    )
+
+    assert res.strategy == NewUserStrategy.__name__
+    assert res.user is not None
+    assert 0 == (
+        res.user.flags & User.FLAG_CREATED_FROM_PARTNER
+    )
 
 
 def test_get_strategy_existing_sl_user():


### PR DESCRIPTION
This PR performs the following changes:

1. Adds a new optional parameter `from_partner` for the user creation. When this parameter is set, it will not send any notification to the user nor give the user any trial period.
2. Set the parameter explicitly to False when logging in with Proton (the user has started the flow, so even if it's linked to a partner, it's not created by a partner)