### PR TITLE
Fix hover color in login with proton button

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -193,3 +193,6 @@ textarea.parsley-error {
     background-color:white;
     color:#6d4aff;
 }
+.proton-button:hover {
+    background-color: #1b1340;
+}


### PR DESCRIPTION
Updated background on hover for the "Login with Proton" buttons in order to use the same as the Proton background