### PR TITLE
Fix: Missing renamed methods

### DIFF
--- a/templates/dashboard/pricing.html
+++ b/templates/dashboard/pricing.html
@@ -87,7 +87,7 @@
         </a>
       </div>
 
-      {% set sub = current_user.get_subscription() %}
+      {% set sub = current_user.get_paddle_subscription() %}
       {% if sub and sub.cancelled %}
         <div class="alert alert-primary" role="alert">
           You have an active subscription until {{ sub.next_bill_date.strftime("%Y-%m-%d") }}. <br>

--- a/templates/dashboard/setting.html
+++ b/templates/dashboard/setting.html
@@ -27,9 +27,9 @@
         {% if current_user.lifetime %}
           You have lifetime access to the Premium plan.
         {% elif current_user.lifetime_or_active_subscription() %}
-          {% if current_user.get_subscription() %}
+          {% if current_user.get_paddle_subscription() %}
             <div>
-              {{ current_user.get_subscription().plan_name() }} plan subscribed via Paddle.
+              {{ current_user.get_paddle_subscription().plan_name() }} plan subscribed via Paddle.
               <a href="{{ url_for('dashboard.billing') }}">
                 Manage Subscription ➡
               </a>


### PR DESCRIPTION
Rename last occurrences of `get_subscription` to `get_paddle_subscription`