### PR TITLE
Show premium subscription managed by partner

### DIFF
--- a/templates/dashboard/setting.html
+++ b/templates/dashboard/setting.html
@@ -70,6 +70,12 @@
               </a>
             </div>
           {% endif %}
+
+          {% if partner_sub %}
+            <div>
+              Premium subscription managed by {{ partner_name }}.
+            </div>
+          {% endif %}
         {% elif current_user.in_trial() %}
           Your Premium trial expires {{ current_user.trial_end | dt }}.
         {% else %}


### PR DESCRIPTION
This PR performs the following changes:

- On the Settings page, in case of having a subscription managed by a partner, show `Premium subscription managed by {{ partner_name }}`

![image](https://user-images.githubusercontent.com/74399022/175925340-df9ef8d7-7279-4d7b-9941-f2a359cbe341.png)
