### PR TITLE
Restrict the number of free alias for new free users

### DIFF
--- a/app/api/views/user_info.py
+++ b/app/api/views/user_info.py
@@ -18,6 +18,7 @@ def user_to_dict(user: User) -> dict:
         "is_premium": user.is_premium(),
         "email": user.email,
         "in_trial": user.in_trial(),
+        "max_alias_free_plan": user.max_alias_for_free_account(),
     }
 
     if user.profile_picture_id:
@@ -33,6 +34,13 @@ def user_to_dict(user: User) -> dict:
 def user_info():
     """
     Return user info given the api-key
+
+    Output as json
+    - name
+    - is_premium
+    - email
+    - in_trial
+    - max_alias_free
     """
     user = g.user
 
@@ -46,7 +54,6 @@ def update_user_info():
     Input
     - profile_picture (optional): base64 of the profile picture. Set to null to remove the profile picture
     - name (optional)
-
     """
     user = g.user
     data = request.get_json() or {}

--- a/app/config.py
+++ b/app/config.py
@@ -97,6 +97,8 @@ except Exception:
     print("MAX_NB_EMAIL_FREE_PLAN is not set, use 5 as default value")
     MAX_NB_EMAIL_FREE_PLAN = 5
 
+MAX_NB_EMAIL_OLD_FREE_PLAN = int(os.environ.get("MAX_NB_EMAIL_OLD_FREE_PLAN", 15))
+
 # maximum number of directory a premium user can create
 MAX_NB_DIRECTORY = 50
 MAX_NB_SUBDOMAIN = 5

--- a/app/models.py
+++ b/app/models.py
@@ -295,7 +295,7 @@ class User(Base, ModelMixin, UserMixin, PasswordOracle):
 
     FLAG_FREE_DISABLE_CREATE_ALIAS = 1 << 0
     FLAG_CREATED_FROM_PARTNER = 1 << 1
-    FLAG_FREE_NEW_ALIAS_LIMIT = 1 << 2
+    FLAG_FREE_OLD_ALIAS_LIMIT = 1 << 2
 
     email = sa.Column(sa.String(256), unique=True, nullable=False)
 
@@ -489,7 +489,7 @@ class User(Base, ModelMixin, UserMixin, PasswordOracle):
     # bitwise flags. Allow for future expansion
     flags = sa.Column(
         sa.BigInteger,
-        default=FLAG_FREE_DISABLE_CREATE_ALIAS | FLAG_FREE_NEW_ALIAS_LIMIT,
+        default=FLAG_FREE_DISABLE_CREATE_ALIAS,
         server_default="0",
         nullable=False,
     )
@@ -723,12 +723,12 @@ class User(Base, ModelMixin, UserMixin, PasswordOracle):
 
     def max_alias_for_free_account(self) -> int:
         if (
-            self.FLAG_FREE_NEW_ALIAS_LIMIT
-            == self.flags & self.FLAG_FREE_NEW_ALIAS_LIMIT
+            self.FLAG_FREE_OLD_ALIAS_LIMIT
+            == self.flags & self.FLAG_FREE_OLD_ALIAS_LIMIT
         ):
-            return config.MAX_NB_EMAIL_FREE_PLAN
-        else:
             return config.MAX_NB_EMAIL_OLD_FREE_PLAN
+        else:
+            return config.MAX_NB_EMAIL_FREE_PLAN
 
     def can_create_new_alias(self) -> bool:
         """

--- a/docs/api.md
+++ b/docs/api.md
@@ -207,7 +207,8 @@ Output: if api key is correct, return a json with user name and whether user is 
   "is_premium": false,
   "email": "john@wick.com",
   "in_trial": true,
-  "profile_picture_url": "https://profile.png"
+  "profile_picture_url": "https://profile.png",
+  "max_alias_free_plan": 5,
 }
 ```
 

--- a/tests/api/test_user_info.py
+++ b/tests/api/test_user_info.py
@@ -1,5 +1,6 @@
 from flask import url_for
 
+from app import config
 from app.models import User
 from tests.api.utils import get_new_user_and_api_key
 from tests.utils import login
@@ -19,6 +20,7 @@ def test_user_in_trial(flask_client):
         "email": user.email,
         "in_trial": True,
         "profile_picture_url": None,
+        "max_alias_free_plan": config.MAX_NB_EMAIL_FREE_PLAN,
     }
 
 


### PR DESCRIPTION
- Old accounts will keep the old value (pending config change)
- To enable this change in prod, we need to:
  - Add the new config
  - Add the flag to current users in prod
  - Redeploy