### PR TITLE
Sanitize the highlight contact id

### DIFF
--- a/app/dashboard/views/alias_contact_manager.py
+++ b/app/dashboard/views/alias_contact_manager.py
@@ -237,9 +237,8 @@ def alias_contact_manager(alias_id):
         try:
             highlight_contact_id = int(request.args.get("highlight_contact_id"))
         except ValueError:
-            flash('Invalid contact id', 'error')
-            return redirect(url_for('dashboard.index'))
-
+            flash("Invalid contact id", "error")
+            return redirect(url_for("dashboard.index"))
 
     alias = Alias.get(alias_id)
 

--- a/app/dashboard/views/alias_contact_manager.py
+++ b/app/dashboard/views/alias_contact_manager.py
@@ -234,7 +234,12 @@ def delete_contact(alias: Alias, contact_id: int):
 def alias_contact_manager(alias_id):
     highlight_contact_id = None
     if request.args.get("highlight_contact_id"):
-        highlight_contact_id = int(request.args.get("highlight_contact_id"))
+        try:
+            highlight_contact_id = int(request.args.get("highlight_contact_id"))
+        except ValueError:
+            flash('Invalid contact id', 'error')
+            return redirect(url_for('dashboard.index'))
+
 
     alias = Alias.get(alias_id)
 

--- a/server.py
+++ b/server.py
@@ -206,6 +206,7 @@ def load_user(alternative_id):
     user = User.get_by(alternative_id=alternative_id)
     if user and user.disabled:
         return None
+    sentry_sdk.set_user({"email": user.email, "id": user.id})
 
     return user
 


### PR DESCRIPTION
- Skip sending the error to sentry. 
- Decorate the sentry errors with user id to be able to debug it