### PR TITLE
Update Dockerfile to use python 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY ./static/package*.json /code/static/
 RUN cd /code/static && npm install
 
 # Main image
-FROM python:3.7
+FROM python:3.10
 
 # Keeps Python from generating .pyc files in the container
 ENV PYTHONDONTWRITEBYTECODE 1


### PR DESCRIPTION
- We still test with python 3.9 for backwards compatibility
- We gain performance improvements of python 3.10