### PR TITLE
Do not allow SVG image uploads

### DIFF
--- a/app/image_validation.py
+++ b/app/image_validation.py
@@ -5,7 +5,6 @@ class ImageFormat(Enum):
     Png = 1
     Jpg = 2
     Webp = 3
-    Svg = 4
     Unknown = 9
 
 
@@ -13,7 +12,6 @@ magic_numbers = {
     ImageFormat.Png: bytes([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]),
     ImageFormat.Jpg: bytes([0xFF, 0xD8, 0xFF, 0xE0]),
     ImageFormat.Webp: bytes([0x52, 0x49, 0x46, 0x46]),
-    ImageFormat.Svg: bytes([0x3C, 0x3F, 0x78, 0x6D, 0x6C]),  # <?xml
 }
 
 
@@ -22,7 +20,6 @@ def detect_image_format(image: bytes) -> ImageFormat:
     for fmt, header in magic_numbers.items():
         if image.startswith(header):
             return fmt
-    # Detect if is svg
 
     # We don't know the type
     return ImageFormat.Unknown

--- a/tests/test_image_validation.py
+++ b/tests/test_image_validation.py
@@ -42,6 +42,6 @@ def test_webp_file_is_detected():
     assert detect_image_format(contents) is ImageFormat.Webp
 
 
-def test_svg_file_is_detected():
+def test_svg_file_is_not_detected():
     contents = read_static_file_contents("icon.svg")
-    assert detect_image_format(contents) is ImageFormat.Svg
+    assert detect_image_format(contents) is ImageFormat.Unknown


### PR DESCRIPTION
Do not allow users to upload SVG images as profile images, so we can avoid having to detect if the SVG is a malformed one.