### PR TITLE
Support next with Proton Link

### DIFF
--- a/app/account_linking.py
+++ b/app/account_linking.py
@@ -276,7 +276,7 @@ def process_link_case(
         return link_user(link_request, current_user, partner)
 
     # There is a SL user registered with the partner. Check if is the current one
-    if partner_user.id == current_user.id:
+    if partner_user.user_id == current_user.id:
         # Update plan
         set_plan_for_partner_user(partner_user, link_request.plan)
         # It's the same user. No need to do anything
@@ -285,5 +285,4 @@ def process_link_case(
             strategy="Link",
         )
     else:
-
         return switch_already_linked_user(link_request, partner_user, current_user)

--- a/app/auth/views/proton.py
+++ b/app/auth/views/proton.py
@@ -146,10 +146,11 @@ def proton_callback():
     handler = ProtonCallbackHandler(proton_client)
     proton_partner = get_proton_partner()
 
+    next_url = session.get("oauth_next")
     if action == Action.Login:
         res = handler.handle_login(proton_partner)
     elif action == Action.Link:
-        res = handler.handle_link(current_user, proton_partner)
+        res = handler.handle_link(current_user, proton_partner, redirect=next_url)
     else:
         raise Exception(f"Unknown Action: {action.name}")
 
@@ -166,5 +167,4 @@ def proton_callback():
     if res.redirect:
         return after_login(res.user, res.redirect, login_from_proton=True)
 
-    next_url = session.get("oauth_next")
     return after_login(res.user, next_url, login_from_proton=True)

--- a/app/proton/proton_callback_handler.py
+++ b/app/proton/proton_callback_handler.py
@@ -67,7 +67,6 @@ class ProtonCallbackHandler:
         self,
         current_user: Optional[User],
         partner: Partner,
-        redirect: Optional[str] = None,
     ) -> ProtonCallbackResult:
         if current_user is None:
             raise Exception("Cannot link account with current_user being None")
@@ -76,14 +75,11 @@ class ProtonCallbackHandler:
             if user is None:
                 return generate_account_not_allowed_to_log_in()
             res = process_link_case(user, current_user, partner)
-            result_redirect = url_for("dashboard.setting")
-            if redirect:
-                result_redirect = redirect
             return ProtonCallbackResult(
                 redirect_to_login=False,
                 flash_message="Account successfully linked",
                 flash_category="success",
-                redirect=result_redirect,
+                redirect=url_for("dashboard.setting"),
                 user=res.user,
             )
         except LinkException as e:

--- a/app/proton/proton_callback_handler.py
+++ b/app/proton/proton_callback_handler.py
@@ -64,7 +64,10 @@ class ProtonCallbackHandler:
             )
 
     def handle_link(
-        self, current_user: Optional[User], partner: Partner
+        self,
+        current_user: Optional[User],
+        partner: Partner,
+        redirect: Optional[str] = None,
     ) -> ProtonCallbackResult:
         if current_user is None:
             raise Exception("Cannot link account with current_user being None")
@@ -73,11 +76,14 @@ class ProtonCallbackHandler:
             if user is None:
                 return generate_account_not_allowed_to_log_in()
             res = process_link_case(user, current_user, partner)
+            result_redirect = url_for("dashboard.setting")
+            if redirect:
+                result_redirect = redirect
             return ProtonCallbackResult(
                 redirect_to_login=False,
                 flash_message="Account successfully linked",
                 flash_category="success",
-                redirect=url_for("dashboard.setting"),
+                redirect=result_redirect,
                 user=res.user,
             )
         except LinkException as e:

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,3 +1,4 @@
+import re
 import secrets
 import string
 import time
@@ -88,6 +89,8 @@ class NextUrlSanitizer:
             else:
                 return None
         if result.path and result.path[0] == "/" and not result.path.startswith("//"):
+            if result.query:
+                return f"{result.path}?{result.query}"
             return result.path
 
         return None
@@ -95,6 +98,17 @@ class NextUrlSanitizer:
 
 def sanitize_next_url(url: Optional[str]) -> Optional[str]:
     return NextUrlSanitizer.sanitize(url, ALLOWED_REDIRECT_DOMAINS)
+
+
+def sanitize_scheme(scheme: Optional[str]) -> Optional[str]:
+    if not scheme:
+        return None
+    if scheme in ["http", "https"]:
+        return None
+    scheme_regex = re.compile("^[a-z.]+$")
+    if scheme_regex.match(scheme):
+        return scheme
+    return None
 
 
 def query2str(query):


### PR DESCRIPTION
This PR adds the following changes:

- Support for `next` in the "Link Proton account" OAuth flow
- Support for passing a `scheme` to the Proton login/link
- Fix a server error when re-linking a Proton account (user already had the same Proton account linked)

