### PR TITLE
Fixes for connect with proton on mobile

### DIFF
--- a/app/api/views/setting.py
+++ b/app/api/views/setting.py
@@ -12,6 +12,7 @@ from app.models import (
     SenderFormatEnum,
     AliasSuffixEnum,
 )
+from app.proton.utils import perform_proton_account_unlink
 
 
 def setting_to_dict(user: User):
@@ -137,3 +138,11 @@ def get_available_domains_for_random_alias_v2():
     ]
 
     return jsonify(ret)
+
+
+@api_bp.route("/setting/unlink_proton_account", methods=["DELETE"])
+@require_api_auth
+def unlink_proton_account():
+    user = g.user
+    perform_proton_account_unlink(user)
+    return jsonify({"ok": True})

--- a/app/auth/views/api_to_cookie.py
+++ b/app/auth/views/api_to_cookie.py
@@ -1,18 +1,14 @@
 import arrow
 from flask import redirect, url_for, request, flash
-from flask_login import current_user, login_user
+from flask_login import login_user
 
 from app.auth.base import auth_bp
-from app.log import LOG
 from app.models import ApiToCookieToken
 from app.utils import sanitize_next_url
 
 
 @auth_bp.route("/api_to_cookie", methods=["GET"])
 def api_to_cookie():
-    if current_user.is_authenticated:
-        LOG.d("user is already authenticated, redirect to dashboard")
-        return redirect(url_for("dashboard.index"))
     code = request.args.get("token")
     if not code:
         flash("Missing token", "error")
@@ -23,8 +19,9 @@ def api_to_cookie():
         flash("Missing token", "error")
         return redirect(url_for("auth.login"))
 
-    login_user(token.user)
+    user = token.user
     ApiToCookieToken.delete(token.id, commit=True)
+    login_user(user)
 
     next_url = sanitize_next_url(request.args.get("next"))
     if next_url:

--- a/app/proton/utils.py
+++ b/app/proton/utils.py
@@ -1,8 +1,9 @@
+from newrelic import agent
 from typing import Optional
 
 from app.db import Session
 from app.errors import ProtonPartnerNotSetUp
-from app.models import Partner
+from app.models import Partner, PartnerUser, User
 
 PROTON_PARTNER_NAME = "Proton"
 _PROTON_PARTNER: Optional[Partner] = None
@@ -21,3 +22,14 @@ def get_proton_partner() -> Partner:
 
 def is_proton_partner(partner: Partner) -> bool:
     return partner.name == PROTON_PARTNER_NAME
+
+
+def perform_proton_account_unlink(current_user: User):
+    proton_partner = get_proton_partner()
+    partner_user = PartnerUser.get_by(
+        user_id=current_user.id, partner_id=proton_partner.id
+    )
+    if partner_user is not None:
+        PartnerUser.delete(partner_user.id)
+    Session.commit()
+    agent.record_custom_event("AccountUnlinked", {"partner": proton_partner.name})

--- a/tests/api/test_user_info.py
+++ b/tests/api/test_user_info.py
@@ -21,6 +21,7 @@ def test_user_in_trial(flask_client):
         "in_trial": True,
         "profile_picture_url": None,
         "max_alias_free_plan": config.MAX_NB_EMAIL_FREE_PLAN,
+        "connected_proton_address": None,
     }
 
 

--- a/tests/api/test_user_info.py
+++ b/tests/api/test_user_info.py
@@ -1,9 +1,10 @@
 from flask import url_for
 
 from app import config
-from app.models import User
+from app.models import User, PartnerUser
+from app.proton.utils import get_proton_partner
 from tests.api.utils import get_new_user_and_api_key
-from tests.utils import login
+from tests.utils import login, random_token, random_email
 
 
 def test_user_in_trial(flask_client):
@@ -22,6 +23,34 @@ def test_user_in_trial(flask_client):
         "profile_picture_url": None,
         "max_alias_free_plan": config.MAX_NB_EMAIL_FREE_PLAN,
         "connected_proton_address": None,
+    }
+
+
+def test_user_linked_to_proton(flask_client):
+    user, api_key = get_new_user_and_api_key()
+    partner = get_proton_partner()
+    partner_email = random_email()
+    PartnerUser.create(
+        user_id=user.id,
+        partner_id=partner.id,
+        external_user_id=random_token(),
+        partner_email=partner_email,
+        commit=True,
+    )
+
+    r = flask_client.get(
+        url_for("api.user_info"), headers={"Authentication": api_key.code}
+    )
+
+    assert r.status_code == 200
+    assert r.json == {
+        "is_premium": True,
+        "name": "Test User",
+        "email": user.email,
+        "in_trial": True,
+        "profile_picture_url": None,
+        "max_alias_free_plan": config.MAX_NB_EMAIL_FREE_PLAN,
+        "connected_proton_address": partner_email,
     }
 
 


### PR DESCRIPTION
This PR adds the following changes for making `Connect with Proton` available on mobile:

- `DELETE /api/setting/unlink_proton_account` for unlinking the Proton account from the API
- Add `connected_proton_address: Optional[str]` on the response of `GET /api/user_info`
- Fixes on the `/api_to_cookie` endpoint for ensuring we redirect the user even if they're already authenticated
- Fixes in the Proton OAuth callback for invalid flows
- 