### PR TITLE
Corrections & consistent footer

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -13,7 +13,7 @@
                alt="SimpleLogin logo">
         </a>
         <!-- End Logo -->
-        <p class="small text-white">SimpleLogin is an open-source email alias solution to protect your email address.</p>
+        <p class="small text-white">SimpleLogin is an <a href="https://github.com/simple-login">open source</a> email alias solution to protect your email address.</p>
         <p class="small text-white">
           SimpleLogin is the product of SimpleLogin SAS, registered in France under the SIREN number 884302134.
           SimpleLogin SAS is part of <a href="https://proton.me">Proton AG</a>.
@@ -31,7 +31,7 @@
           <li>
             <a class="list-group-item text-white footer-item "
                href="https://github.com/simple-login/app">
-              Github
+              GitHub
               <img src="https://img.shields.io/github/stars/simple-login/app?style=social"
                    alt="GitHub">
             </a>
@@ -111,6 +111,12 @@
         <ul class="list-group list-group-transparent list-group-white list-group-flush list-group-borderless mb-0 footer-list-group">
           <li>
             <a class="list-group-item text-white footer-item"
+               href="https://simplelogin.io/blog/email-alias-vs-plus-sign/">
+              vs Plus Sign (+) Trick
+            </a>
+          </li>
+          <li>
+            <a class="list-group-item text-white footer-item"
                href="https://simplelogin.io/blog/vs-firefox-relay/">
               vs
               Firefox Relay
@@ -118,14 +124,22 @@
           </li>
           <li>
             <a class="list-group-item text-white footer-item"
-               href="https://simplelogin.io/blog/email-alias-vs-plus-sign/">
-              vs Plus Sign (+) Trick
+               href="https://simplelogin.io/blog/vs-burner-mail/">
+              vs
+              Burner Mail
+            </a>
+          </li>
+          <li>
+            <a class="list-group-item text-white footer-item"
+               href="https://simplelogin.io/blog/alternative-33mail/">
+              vs
+              33mail
             </a>
           </li>
         </ul>
       </div>
       <div class="col-sm-4 col-lg-2 mb-4">
-        <h3 class="h6 text-white">Features</h3>
+        <h3 class="h6 text-white">Downloads</h3>
         <ul class="list-group list-group-transparent list-group-white list-group-flush list-group-borderless mb-0 footer-list-group">
           <li>
             <a class="list-group-item text-white footer-item "

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -139,7 +139,7 @@
         </ul>
       </div>
       <div class="col-sm-4 col-lg-2 mb-4">
-        <h3 class="h6 text-white">Downloads</h3>
+        <h3 class="h4 text-white">Downloads</h3>
         <ul class="list-group list-group-transparent list-group-white list-group-flush list-group-borderless mb-0 footer-list-group">
           <li>
             <a class="list-group-item text-white footer-item "


### PR DESCRIPTION
- _Downloads_ instead of _Features_
- Deleted _-_ in the _open source_
- Made _open source_ a link
- Added missing comparisons (consistency with the main page)
- Fixed GitHub spelling

Basically made the footer consistent with the main page.

Also a side note, the Twitter handle isn't updated on the GitHub organization.