### PR TITLE
Notify another mailbox about an email sent by a mailbox to a reverse alias

### DIFF
--- a/app/email_utils.py
+++ b/app/email_utils.py
@@ -943,7 +943,7 @@ def add_header(msg: Message, text_header, html_header=None) -> Message:
         if type(payload) is str:
             clone_msg = copy(msg)
             new_payload = f"""{text_header}
----
+------------------------------
 {decode_text(payload, encoding)}"""
             clone_msg.set_payload(encode_text(new_payload, encoding))
             return clone_msg

--- a/app/email_utils.py
+++ b/app/email_utils.py
@@ -934,7 +934,8 @@ def decode_text(text: str, encoding: EmailEncoding = EmailEncoding.NO) -> str:
 
 def add_header(msg: Message, text_header, html_header=None) -> Message:
     if not html_header:
-        html_header = text_header
+        html_header = text_header.replace("\n", "<br>")
+
     content_type = msg.get_content_type().lower()
     if content_type == "text/plain":
         encoding = get_encoding(msg)

--- a/email_handler.py
+++ b/email_handler.py
@@ -1300,11 +1300,12 @@ def notify_mailbox(alias, mailbox, other_mb: Mailbox, msg, orig_to, orig_cc):
         f"""Email sent from alias {alias.email} \n
 To: {msg[headers.TO] or "Empty"} \n
 CC: {msg[headers.CC] or "Empty"}\n
-Sent from mailbox {mailbox.email}\n,
+Sent from mailbox {mailbox.email}\n
 **** Don't forget to remove this section when replying ****
 """,
     )
-    add_or_replace_header(notif, headers.FROM, config.NOREPLY)
+    # use alias as From to hint that the email is sent from the alias
+    add_or_replace_header(notif, headers.FROM, alias.email)
     # keep the reverse alias in CC and To header so user can reply more easily
     add_or_replace_header(notif, headers.TO, orig_to)
     add_or_replace_header(notif, headers.CC, orig_cc)
@@ -1313,9 +1314,11 @@ Sent from mailbox {mailbox.email}\n,
         headers.SUBJECT,
         f"{mailbox.email} on behalf of {alias.email} to {msg[headers.TO] or '<>'}, cc {msg[headers.CC] or '<>'}",
     )
+
     # add DKIM
-    email_domain = NOREPLY[NOREPLY.find("@") + 1 :]
+    email_domain = alias.email[alias.email.find("@") + 1 :]
     add_dkim_signature(msg, email_domain)
+
     transaction = TransactionalEmail.create(email=other_mb.email, commit=True)
     # use a different envelope sender for each transactional email (aka VERP)
     sl_sendmail(

--- a/email_handler.py
+++ b/email_handler.py
@@ -1297,23 +1297,14 @@ def notify_mailbox(alias, mailbox, other_mb: Mailbox, msg, orig_to, orig_cc):
     )
     notif = add_header(
         msg,
-        f"""Email sent from alias {alias.email} \n
-To: {msg[headers.TO] or "Empty"} \n
-CC: {msg[headers.CC] or "Empty"}\n
-Sent from mailbox {mailbox.email}\n
-**** Don't forget to remove this section when replying ****
-""",
+        f"""**** Don't forget to remove this section if you reply to this email ****
+Email sent on behalf of alias {alias.email} using mailbox {mailbox.email}""",
     )
     # use alias as From to hint that the email is sent from the alias
     add_or_replace_header(notif, headers.FROM, alias.email)
     # keep the reverse alias in CC and To header so user can reply more easily
     add_or_replace_header(notif, headers.TO, orig_to)
     add_or_replace_header(notif, headers.CC, orig_cc)
-    add_or_replace_header(
-        notif,
-        headers.SUBJECT,
-        f"{mailbox.email} on behalf of {alias.email} to {msg[headers.TO] or '<>'}, cc {msg[headers.CC] or '<>'}",
-    )
 
     # add DKIM
     email_domain = alias.email[alias.email.find("@") + 1 :]


### PR DESCRIPTION
In case an alias has multiple mailboxes that belong to several people, it's useful for other people to know when an email is sent *from* an alias, i.e. a mailbox has sent an email to a reverse alias.