### PR TITLE
Fix: Only override postfix port when enabling TLS if the port is set to be 25

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -111,9 +111,7 @@ POSTFIX_SERVER = os.environ.get("POSTFIX_SERVER", "240.0.0.1")
 DISABLE_REGISTRATION = "DISABLE_REGISTRATION" in os.environ
 
 # allow using a different postfix port, useful when developing locally
-POSTFIX_PORT = 25
-if "POSTFIX_PORT" in os.environ:
-    POSTFIX_PORT = int(os.environ["POSTFIX_PORT"])
+POSTFIX_PORT = int(os.environ.get("POSTFIX_PORT", 25))
 
 # Use port 587 instead of 25 when sending emails through Postfix
 # Useful when calling Postfix from an external network

--- a/app/config.py
+++ b/app/config.py
@@ -116,6 +116,7 @@ POSTFIX_PORT = int(os.environ.get("POSTFIX_PORT", 25))
 # Use port 587 instead of 25 when sending emails through Postfix
 # Useful when calling Postfix from an external network
 POSTFIX_SUBMISSION_TLS = "POSTFIX_SUBMISSION_TLS" in os.environ
+POSTFIX_TIMEOUT = os.environ.get("POSTFIX_TIMEOUT", 3)
 
 # ["domain1.com", "domain2.com"]
 OTHER_ALIAS_DOMAINS = sl_getenv("OTHER_ALIAS_DOMAINS", list)

--- a/app/mail_sender.py
+++ b/app/mail_sender.py
@@ -123,7 +123,7 @@ class MailSender:
             smtp_port = config.POSTFIX_PORT
         try:
             start = time.time()
-            with SMTP(config.POSTFIX_SERVER, smtp_port) as smtp:
+            with SMTP(config.POSTFIX_SERVER, smtp_port, config.POSTFIX_TIMEOUT) as smtp:
                 if config.POSTFIX_SUBMISSION_TLS:
                     smtp.starttls()
 

--- a/app/mail_sender.py
+++ b/app/mail_sender.py
@@ -117,7 +117,7 @@ class MailSender:
             return True
 
     def _send_to_smtp(self, send_request: SendRequest, retries: int) -> bool:
-        if config.POSTFIX_SUBMISSION_TLS:
+        if config.POSTFIX_SUBMISSION_TLS and config.POSTFIX_PORT == 25:
             smtp_port = 587
         else:
             smtp_port = config.POSTFIX_PORT


### PR DESCRIPTION
- Override only smtp port if set to the default smtp port when enabling TLS
- Set a timeout for postfix