### PR TITLE
Fix: Set oneclick link for unsubscribe of the newsletter for tx emails

### DIFF
--- a/app/email_utils.py
+++ b/app/email_utils.py
@@ -83,15 +83,15 @@ def render(template_name, **kwargs) -> str:
 
 
 def send_welcome_email(user):
-    to_email, unsubscribe_link, via_email = user.get_communication_email()
-    if not to_email:
+    comm_alias, unsubscribe_link, via_email = user.get_communication_email()
+    if not comm_alias:
         return
 
     # whether this email is sent to an alias
-    alias = to_email if to_email != user.email else None
+    alias = comm_alias.email if comm_alias.email != user.email else None
 
     send_email(
-        to_email,
+        comm_alias.email,
         f"Welcome to SimpleLogin",
         render("com/welcome.txt", user=user, alias=alias),
         render("com/welcome.html", user=user, alias=alias),

--- a/app/models.py
+++ b/app/models.py
@@ -945,7 +945,7 @@ class User(Base, ModelMixin, UserMixin, PasswordOracle):
                     return alias, unsub.link, unsub.via_email
                 # alias disabled -> user doesn't want to receive newsletter
                 else:
-                    return None, '', False
+                    return None, "", False
             else:
                 # do not handle http POST unsubscribe
                 if config.UNSUBSCRIBER:
@@ -958,7 +958,7 @@ class User(Base, ModelMixin, UserMixin, PasswordOracle):
                         True,
                     )
 
-        return None, '', False
+        return None, "", False
 
     def available_sl_domains(self) -> [str]:
         """

--- a/app/models.py
+++ b/app/models.py
@@ -928,7 +928,7 @@ class User(Base, ModelMixin, UserMixin, PasswordOracle):
     def two_factor_authentication_enabled(self) -> bool:
         return self.enable_otp or self.fido_enabled()
 
-    def get_communication_email(self) -> (Optional[str], str, bool):
+    def get_communication_email(self) -> (Optional[Alias], str, bool):
         """
         Return
         - the email that user uses to receive email communication. None if user unsubscribes from newsletter
@@ -942,10 +942,10 @@ class User(Base, ModelMixin, UserMixin, PasswordOracle):
                     unsub = UnsubscribeEncoder.encode(
                         UnsubscribeAction.DisableAlias, alias.id
                     )
-                    return alias.email, unsub.link, unsub.via_email
+                    return alias, unsub.link, unsub.via_email
                 # alias disabled -> user doesn't want to receive newsletter
                 else:
-                    return None, None, False
+                    return None, '', False
             else:
                 # do not handle http POST unsubscribe
                 if config.UNSUBSCRIBER:
@@ -958,7 +958,7 @@ class User(Base, ModelMixin, UserMixin, PasswordOracle):
                         True,
                     )
 
-        return None, None, False
+        return None, '', False
 
     def available_sl_domains(self) -> [str]:
         """

--- a/app/newsletter_utils.py
+++ b/app/newsletter_utils.py
@@ -6,7 +6,7 @@ from app.config import ROOT_DIR, URL
 from app.email_utils import send_email
 from app.handler.unsubscribe_encoder import UnsubscribeEncoder, UnsubscribeAction
 from app.log import LOG
-from app.models import NewsletterUser, Alias
+from app.models import NewsletterUser
 
 
 def send_newsletter_to_user(newsletter, user) -> (bool, str):
@@ -40,7 +40,7 @@ def send_newsletter_to_user(newsletter, user) -> (bool, str):
                 unsubscribe_oneclick=unsubscribe_oneclick,
             ),
             unsubscribe_link=unsubscribe_link,
-            unsubscribe_via_email=via_email
+            unsubscribe_via_email=via_email,
         )
 
         NewsletterUser.create(newsletter_id=newsletter.id, user_id=user.id, commit=True)

--- a/app/newsletter_utils.py
+++ b/app/newsletter_utils.py
@@ -4,8 +4,9 @@ from jinja2 import Environment, FileSystemLoader
 
 from app.config import ROOT_DIR, URL
 from app.email_utils import send_email
+from app.handler.unsubscribe_encoder import UnsubscribeEncoder, UnsubscribeAction
 from app.log import LOG
-from app.models import NewsletterUser
+from app.models import NewsletterUser, Alias
 
 
 def send_newsletter_to_user(newsletter, user) -> (bool, str):
@@ -16,12 +17,18 @@ def send_newsletter_to_user(newsletter, user) -> (bool, str):
         html_template = env.from_string(newsletter.html)
         text_template = env.from_string(newsletter.plain_text)
 
-        to_email, unsubscribe_link, via_email = user.get_communication_email()
-        if not to_email:
+        comm_alias, unsubscribe_link, via_email = user.get_communication_email()
+        if not comm_alias:
             return False, f"{user} not subscribed to newsletter"
 
+        unsubscribe_oneclick = unsubscribe_link
+        if via_email:
+            unsubscribe_oneclick = UnsubscribeEncoder.encode(
+                UnsubscribeAction.DisableAlias, comm_alias.id
+            )
+
         send_email(
-            to_email,
+            comm_alias.email,
             newsletter.subject,
             text_template.render(
                 user=user,
@@ -30,9 +37,10 @@ def send_newsletter_to_user(newsletter, user) -> (bool, str):
             html_template.render(
                 user=user,
                 URL=URL,
-                unsubscribe_link=unsubscribe_link,
+                unsubscribe_oneclick=unsubscribe_oneclick,
             ),
             unsubscribe_link=unsubscribe_link,
+            unsubscribe_via_email=via_email
         )
 
         NewsletterUser.create(newsletter_id=newsletter.id, user_id=user.id, commit=True)

--- a/job_runner.py
+++ b/job_runner.py
@@ -22,15 +22,15 @@ from server import create_light_app
 
 
 def onboarding_send_from_alias(user):
-    to_email, unsubscribe_link, via_email = user.get_communication_email()
-    if not to_email:
+    comm_alias, unsubscribe_link, via_email = user.get_communication_email()
+    if not comm_alias.email:
         return
 
     send_email(
-        to_email,
+        comm_alias.email,
         "SimpleLogin Tip: Send emails from your alias",
-        render("com/onboarding/send-from-alias.txt.j2", user=user, to_email=to_email),
-        render("com/onboarding/send-from-alias.html", user=user, to_email=to_email),
+        render("com/onboarding/send-from-alias.txt.j2", user=user, to_email=comm_alias.email),
+        render("com/onboarding/send-from-alias.html", user=user, to_email=comm_alias.email),
         unsubscribe_link,
         via_email,
         retries=3,
@@ -39,15 +39,15 @@ def onboarding_send_from_alias(user):
 
 
 def onboarding_pgp(user):
-    to_email, unsubscribe_link, via_email = user.get_communication_email()
-    if not to_email:
+    comm_alias, unsubscribe_link, via_email = user.get_communication_email()
+    if not comm_alias:
         return
 
     send_email(
-        to_email,
+        comm_alias.email,
         "SimpleLogin Tip: Secure your emails with PGP",
-        render("com/onboarding/pgp.txt", user=user, to_email=to_email),
-        render("com/onboarding/pgp.html", user=user, to_email=to_email),
+        render("com/onboarding/pgp.txt", user=user, to_email=comm_alias.email),
+        render("com/onboarding/pgp.html", user=user, to_email=comm_alias.email),
         unsubscribe_link,
         via_email,
         retries=3,
@@ -56,15 +56,15 @@ def onboarding_pgp(user):
 
 
 def onboarding_browser_extension(user):
-    to_email, unsubscribe_link, via_email = user.get_communication_email()
-    if not to_email:
+    comm_alias, unsubscribe_link, via_email = user.get_communication_email()
+    if not comm_alias:
         return
 
     send_email(
-        to_email,
+        comm_alias.email,
         "SimpleLogin Tip: Chrome/Firefox/Safari extensions and Android/iOS apps",
-        render("com/onboarding/browser-extension.txt", user=user, to_email=to_email),
-        render("com/onboarding/browser-extension.html", user=user, to_email=to_email),
+        render("com/onboarding/browser-extension.txt", user=user, to_email=comm_alias.email),
+        render("com/onboarding/browser-extension.html", user=user, to_email=comm_alias.email),
         unsubscribe_link,
         via_email,
         retries=3,
@@ -73,15 +73,15 @@ def onboarding_browser_extension(user):
 
 
 def onboarding_mailbox(user):
-    to_email, unsubscribe_link, via_email = user.get_communication_email()
-    if not to_email:
+    comm_alias, unsubscribe_link, via_email = user.get_communication_email()
+    if not comm_alias:
         return
 
     send_email(
-        to_email,
+        comm_alias.email,
         "SimpleLogin Tip: Multiple mailboxes",
-        render("com/onboarding/mailbox.txt", user=user, to_email=to_email),
-        render("com/onboarding/mailbox.html", user=user, to_email=to_email),
+        render("com/onboarding/mailbox.txt", user=user, to_email=comm_alias.email),
+        render("com/onboarding/mailbox.html", user=user, to_email=comm_alias.email),
         unsubscribe_link,
         via_email,
         retries=3,
@@ -90,19 +90,19 @@ def onboarding_mailbox(user):
 
 
 def welcome_proton(user):
-    to_email, _, _ = user.get_communication_email()
-    if not to_email:
+    comm_alias, _, _ = user.get_communication_email()
+    if not comm_alias:
         return
 
     send_email(
-        to_email,
+        comm_alias.email,
         "Welcome to SimpleLogin, an email masking service provided by Proton",
         render(
             "com/onboarding/welcome-proton-user.txt.jinja2",
             user=user,
-            to_email=to_email,
+            to_email=comm_alias.email,
         ),
-        render("com/onboarding/welcome-proton-user.html", user=user, to_email=to_email),
+        render("com/onboarding/welcome-proton-user.html", user=user, to_email=comm_alias.email),
         retries=3,
         ignore_smtp_error=True,
     )

--- a/job_runner.py
+++ b/job_runner.py
@@ -29,8 +29,14 @@ def onboarding_send_from_alias(user):
     send_email(
         comm_alias.email,
         "SimpleLogin Tip: Send emails from your alias",
-        render("com/onboarding/send-from-alias.txt.j2", user=user, to_email=comm_alias.email),
-        render("com/onboarding/send-from-alias.html", user=user, to_email=comm_alias.email),
+        render(
+            "com/onboarding/send-from-alias.txt.j2",
+            user=user,
+            to_email=comm_alias.email,
+        ),
+        render(
+            "com/onboarding/send-from-alias.html", user=user, to_email=comm_alias.email
+        ),
         unsubscribe_link,
         via_email,
         retries=3,
@@ -63,8 +69,14 @@ def onboarding_browser_extension(user):
     send_email(
         comm_alias.email,
         "SimpleLogin Tip: Chrome/Firefox/Safari extensions and Android/iOS apps",
-        render("com/onboarding/browser-extension.txt", user=user, to_email=comm_alias.email),
-        render("com/onboarding/browser-extension.html", user=user, to_email=comm_alias.email),
+        render(
+            "com/onboarding/browser-extension.txt", user=user, to_email=comm_alias.email
+        ),
+        render(
+            "com/onboarding/browser-extension.html",
+            user=user,
+            to_email=comm_alias.email,
+        ),
         unsubscribe_link,
         via_email,
         retries=3,
@@ -102,7 +114,11 @@ def welcome_proton(user):
             user=user,
             to_email=comm_alias.email,
         ),
-        render("com/onboarding/welcome-proton-user.html", user=user, to_email=comm_alias.email),
+        render(
+            "com/onboarding/welcome-proton-user.html",
+            user=user,
+            to_email=comm_alias.email,
+        ),
         retries=3,
         ignore_smtp_error=True,
     )

--- a/server.py
+++ b/server.py
@@ -841,8 +841,8 @@ def register_custom_commands(app):
                 LOG.i(f"User {user_id} was maybe deleted in the meantime")
                 continue
 
-            to_email, unsubscribe_link, via_email = user.get_communication_email()
-            if not to_email:
+            comm_alias, unsubscribe_link, via_email = user.get_communication_email()
+            if not comm_alias.email:
                 continue
 
             sent, error_msg = send_newsletter_to_user(newsletter, user)

--- a/templates/emails/base.html
+++ b/templates/emails/base.html
@@ -592,6 +592,7 @@
                         {% block footer %}{% endblock %}
                       </p>
                       {% if unsubscribe_oneclick is defined %}
+
                         <p class="f-fallback sub align-center"
                            style="font-size: 13px;
                                   line-height: 1.625;

--- a/templates/emails/base.html
+++ b/templates/emails/base.html
@@ -591,6 +591,15 @@
                         <br />
                         {% block footer %}{% endblock %}
                       </p>
+                      {% if unsubscribe_oneclick is defined %}
+                        <p class="f-fallback sub align-center"
+                           style="font-size: 13px;
+                                  line-height: 1.625;
+                                  text-align: center;
+                                  margin: .4em 0 1.1875em;">
+                          <a href="{{ unsubscribe_oneclick }}">Unsubscribe from our newsletter</a>
+                        </p>
+                      {% endif %}
                       <p class="f-fallback sub align-center"
                          style="font-size: 13px;
                                 line-height: 1.625;

--- a/templates/emails/com/newsletter.html
+++ b/templates/emails/com/newsletter.html
@@ -1,1 +1,0 @@
-{% extends "base.html" %}

--- a/templates/emails/com/newsletter.html
+++ b/templates/emails/com/newsletter.html
@@ -1,12 +1,1 @@
 {% extends "base.html" %}
-
-{% block footer %}
-
-  <p class="f-fallback sub align-center"
-     style="font-size: 13px;
-            line-height: 1.625;
-            text-align: center;
-            margin: .4em 0 1.1875em;">
-    <a href="{{ unsubscribe_link }}">Unsubscribe from our newsletter</a>
-  </p>
-{% endblock %}

--- a/tests/jobs/test_send_proton_welcome.py
+++ b/tests/jobs/test_send_proton_welcome.py
@@ -10,5 +10,5 @@ def test_send_welcome_proton_email():
     sent_mails = mail_sender.get_stored_emails()
     assert len(sent_mails) == 1
     sent_mail = sent_mails[0]
-    to_email, _, _ = user.get_communication_email()
-    sent_mail.envelope_to = to_email
+    comm_alias, _, _ = user.get_communication_email()
+    sent_mail.envelope_to = comm_alias.email


### PR DESCRIPTION
Will only be set if the `unsubscribe_oneclick` variable is set for the template to prevent normal transactional emails from having it