### PR TITLE
Fix: Return email in the get_communication_email always

### DIFF
--- a/app/email_utils.py
+++ b/app/email_utils.py
@@ -83,15 +83,15 @@ def render(template_name, **kwargs) -> str:
 
 
 def send_welcome_email(user):
-    comm_alias, unsubscribe_link, via_email = user.get_communication_email()
-    if not comm_alias:
+    comm_email, unsubscribe_link, via_email = user.get_communication_email()
+    if not comm_email:
         return
 
     # whether this email is sent to an alias
-    alias = comm_alias.email if comm_alias.email != user.email else None
+    alias = comm_email if comm_email != user.email else None
 
     send_email(
-        comm_alias.email,
+        comm_email,
         f"Welcome to SimpleLogin",
         render("com/welcome.txt", user=user, alias=alias),
         render("com/welcome.html", user=user, alias=alias),

--- a/app/models.py
+++ b/app/models.py
@@ -928,7 +928,7 @@ class User(Base, ModelMixin, UserMixin, PasswordOracle):
     def two_factor_authentication_enabled(self) -> bool:
         return self.enable_otp or self.fido_enabled()
 
-    def get_communication_email(self) -> (Optional[Alias], str, bool):
+    def get_communication_email(self) -> (Optional[str], str, bool):
         """
         Return
         - the email that user uses to receive email communication. None if user unsubscribes from newsletter
@@ -942,7 +942,7 @@ class User(Base, ModelMixin, UserMixin, PasswordOracle):
                     unsub = UnsubscribeEncoder.encode(
                         UnsubscribeAction.DisableAlias, alias.id
                     )
-                    return alias, unsub.link, unsub.via_email
+                    return alias.email, unsub.link, unsub.via_email
                 # alias disabled -> user doesn't want to receive newsletter
                 else:
                     return None, "", False

--- a/job_runner.py
+++ b/job_runner.py
@@ -22,21 +22,19 @@ from server import create_light_app
 
 
 def onboarding_send_from_alias(user):
-    comm_alias, unsubscribe_link, via_email = user.get_communication_email()
-    if not comm_alias.email:
+    comm_email, unsubscribe_link, via_email = user.get_communication_email()
+    if not comm_email:
         return
 
     send_email(
-        comm_alias.email,
+        comm_email,
         "SimpleLogin Tip: Send emails from your alias",
         render(
             "com/onboarding/send-from-alias.txt.j2",
             user=user,
-            to_email=comm_alias.email,
+            to_email=comm_email,
         ),
-        render(
-            "com/onboarding/send-from-alias.html", user=user, to_email=comm_alias.email
-        ),
+        render("com/onboarding/send-from-alias.html", user=user, to_email=comm_email),
         unsubscribe_link,
         via_email,
         retries=3,
@@ -45,15 +43,15 @@ def onboarding_send_from_alias(user):
 
 
 def onboarding_pgp(user):
-    comm_alias, unsubscribe_link, via_email = user.get_communication_email()
-    if not comm_alias:
+    comm_email, unsubscribe_link, via_email = user.get_communication_email()
+    if not comm_email:
         return
 
     send_email(
-        comm_alias.email,
+        comm_email,
         "SimpleLogin Tip: Secure your emails with PGP",
-        render("com/onboarding/pgp.txt", user=user, to_email=comm_alias.email),
-        render("com/onboarding/pgp.html", user=user, to_email=comm_alias.email),
+        render("com/onboarding/pgp.txt", user=user, to_email=comm_email),
+        render("com/onboarding/pgp.html", user=user, to_email=comm_email),
         unsubscribe_link,
         via_email,
         retries=3,
@@ -62,20 +60,22 @@ def onboarding_pgp(user):
 
 
 def onboarding_browser_extension(user):
-    comm_alias, unsubscribe_link, via_email = user.get_communication_email()
-    if not comm_alias:
+    comm_email, unsubscribe_link, via_email = user.get_communication_email()
+    if not comm_email:
         return
 
     send_email(
-        comm_alias.email,
+        comm_email,
         "SimpleLogin Tip: Chrome/Firefox/Safari extensions and Android/iOS apps",
         render(
-            "com/onboarding/browser-extension.txt", user=user, to_email=comm_alias.email
+            "com/onboarding/browser-extension.txt",
+            user=user,
+            to_email=comm_email,
         ),
         render(
             "com/onboarding/browser-extension.html",
             user=user,
-            to_email=comm_alias.email,
+            to_email=comm_email,
         ),
         unsubscribe_link,
         via_email,
@@ -85,16 +85,16 @@ def onboarding_browser_extension(user):
 
 
 def onboarding_mailbox(user):
-    comm_alias, unsubscribe_link, via_email = user.get_communication_email()
-    if not comm_alias:
+    comm_email, unsubscribe_link, via_email = user.get_communication_email()
+    if not comm_email:
         return
 
     send_email(
-        comm_alias.email,
+        comm_email,
         "SimpleLogin Tip: Multiple mailboxes",
-        render("com/onboarding/mailbox.txt", user=user, to_email=comm_alias.email),
-        render("com/onboarding/mailbox.html", user=user, to_email=comm_alias.email),
-        unsubscribe_link,
+        render("com/onboarding/mailbox.txt", user=user, to_email=comm_email),
+        render("com/onboarding/mailbox.html", user=user, to_email=comm_email),
+        *unsubscribe_link,
         via_email,
         retries=3,
         ignore_smtp_error=True,
@@ -102,22 +102,22 @@ def onboarding_mailbox(user):
 
 
 def welcome_proton(user):
-    comm_alias, _, _ = user.get_communication_email()
-    if not comm_alias:
+    comm_email, _, _ = user.get_communication_email()
+    if not comm_email:
         return
 
     send_email(
-        comm_alias.email,
+        comm_email,
         "Welcome to SimpleLogin, an email masking service provided by Proton",
         render(
             "com/onboarding/welcome-proton-user.txt.jinja2",
             user=user,
-            to_email=comm_alias.email,
+            to_email=comm_email,
         ),
         render(
             "com/onboarding/welcome-proton-user.html",
             user=user,
-            to_email=comm_alias.email,
+            to_email=comm_email,
         ),
         retries=3,
         ignore_smtp_error=True,

--- a/server.py
+++ b/server.py
@@ -841,8 +841,8 @@ def register_custom_commands(app):
                 LOG.i(f"User {user_id} was maybe deleted in the meantime")
                 continue
 
-            comm_alias, unsubscribe_link, via_email = user.get_communication_email()
-            if not comm_alias.email:
+            comm_email, unsubscribe_link, via_email = user.get_communication_email()
+            if not comm_email:
                 continue
 
             sent, error_msg = send_newsletter_to_user(newsletter, user)

--- a/tests/jobs/test_send_proton_welcome.py
+++ b/tests/jobs/test_send_proton_welcome.py
@@ -10,5 +10,5 @@ def test_send_welcome_proton_email():
     sent_mails = mail_sender.get_stored_emails()
     assert len(sent_mails) == 1
     sent_mail = sent_mails[0]
-    comm_alias, _, _ = user.get_communication_email()
-    sent_mail.envelope_to = comm_alias.email
+    comm_email, _, _ = user.get_communication_email()
+    sent_mail.envelope_to = comm_email


### PR DESCRIPTION
Search for the alias when sending the newsletter only