### PR TITLE
Fix: Use npm ci instead of install to prevent install different versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:10.17.0-alpine AS npm
 WORKDIR /code
 COPY ./static/package*.json /code/static/
-RUN cd /code/static && npm install
+RUN cd /code/static && npm ci
 
 # Main image
 FROM python:3.10


### PR DESCRIPTION
Thanks to @mlec1 for the fix :+1: 