### PR TITLE
Add sender to PGP message body

### DIFF
--- a/email_handler.py
+++ b/email_handler.py
@@ -840,10 +840,12 @@ def forward_email_to_mailbox(
             orig_subject = msg[headers.SUBJECT]
             orig_subject = get_header_unicode(orig_subject)
             add_or_replace_header(msg, "Subject", mailbox.generic_subject)
+            sender = msg[headers.FROM]
+            sender = get_header_unicode(sender)
             msg = add_header(
                 msg,
-                f"""Forwarded by SimpleLogin to {alias.email} with "{orig_subject}" as subject""",
-                f"""Forwarded by SimpleLogin to {alias.email} with <b>{orig_subject}</b> as subject""",
+                f"""Forwarded by SimpleLogin to {alias.email} from "{sender}" with "{orig_subject}" as subject""",
+                f"""Forwarded by SimpleLogin to {alias.email} from "{sender}" with <b>{orig_subject}</b> as subject""",
             )
 
         try:


### PR DESCRIPTION
I'm using SimpleLogin with PGP encryption enabled for a while, and I'm struggling with one issue. As FROM header is not encrypted, I have selected option **No Name** in **Sender Address Format** for better security. However, I'm losing information who sent these emails, I think the best option is to modify the header to something like this:
 
Forwarded by SimpleLogin to <simplelogin_recipient> **from <sender_addess>** with \<subject> as subject

This PR implements this feature :)