### PR TITLE
Fix recreate alias from trash

### DIFF
--- a/app/dashboard/views/custom_alias.py
+++ b/app/dashboard/views/custom_alias.py
@@ -120,18 +120,11 @@ def custom_alias():
                     email=full_alias
                 )
                 custom_domain = domain_deleted_alias.domain
-                if domain_deleted_alias.user_id == current_user.id:
-                    flash(
-                        f"You have deleted this alias before. You can restore it on "
-                        f"{custom_domain.domain} 'Deleted Alias' page",
-                        "error",
-                    )
-                else:
-                    # should never happen as user can only choose their domains
-                    LOG.e(
-                        "Deleted Alias %s does not belong to user %s",
-                        domain_deleted_alias,
-                    )
+                flash(
+                    f"You have deleted this alias before. You can restore it on "
+                    f"{custom_domain.domain} 'Deleted Alias' page",
+                    "error",
+                )
 
             elif DeletedAlias.get_by(email=full_alias):
                 flash(general_error_msg, "error")

--- a/app/mail_sender.py
+++ b/app/mail_sender.py
@@ -170,7 +170,8 @@ class MailSender:
                 LOG.e(
                     f"Could not send message to smtp server {config.POSTFIX_SERVER}:{config.POSTFIX_PORT}"
                 )
-                self._save_request_to_unsent_dir(send_request)
+                if config.SAVE_UNSENT_DIR:
+                    self._save_request_to_unsent_dir(send_request)
                 return False
 
     def _save_request_to_unsent_dir(


### PR DESCRIPTION
This fixes this scenario:
- user A transfer an alias from his custom domain to user B
- user B deletes this alias
- user tries to create the alias but don't see the error mentioning that the alias should be restored from trash first.