### PR TITLE
Fix drag and drop to upload PGP public key not working on Firefox and Chromium (but working on Safari)

### DIFF
--- a/static/js/utils/drag-drop-into-text.js
+++ b/static/js/utils/drag-drop-into-text.js
@@ -17,6 +17,7 @@ function enableDragDropForPGPKeys(inputID) {
             reader.onloadend = onFileLoaded;
             reader.readAsBinaryString(file);
         }
+        dropArea.classList.remove("dashed-outline");
     }
 
     function onFileLoaded(event) {
@@ -28,10 +29,17 @@ function enableDragDropForPGPKeys(inputID) {
     dropArea.addEventListener("dragenter", (event) => {
         event.stopPropagation();
         event.preventDefault();
+        dropArea.classList.add("dashed-outline");
     });
     dropArea.addEventListener("dragover", (event) => {
         event.stopPropagation();
         event.preventDefault();
+        dropArea.classList.add("dashed-outline");
+    });
+    dropArea.addEventListener("dragleave", (event) => {
+        event.stopPropagation();
+        event.preventDefault();
+        dropArea.classList.remove("dashed-outline");
     });
     dropArea.addEventListener("drop", drop, false);
 }

--- a/static/js/utils/drag-drop-into-text.js
+++ b/static/js/utils/drag-drop-into-text.js
@@ -8,7 +8,8 @@ function enableDragDropForPGPKeys(inputID) {
         let files = event.dataTransfer.files;
         for (let i = 0; i < files.length; i++) {
             let file = files[i];
-            if(file.type !== 'text/plain'){
+            const isValidPgpFile = file.type === 'text/plain' || file.name.endsWith('.asc') || file.name.endsWith('.pub') || file.name.endsWith('.pgp') || file.name.endsWith('.key');
+            if (!isValidPgpFile) {
                 toastr.warning(`File ${file.name} is not a public key file`);
                 continue;
             }
@@ -24,5 +25,13 @@ function enableDragDropForPGPKeys(inputID) {
     }
 
     const dropArea = $(inputID).get(0);
+    dropArea.addEventListener("dragenter", (event) => {
+        event.stopPropagation();
+        event.preventDefault();
+    });
+    dropArea.addEventListener("dragover", (event) => {
+        event.stopPropagation();
+        event.preventDefault();
+    });
     dropArea.addEventListener("drop", drop, false);
 }

--- a/static/style.css
+++ b/static/style.css
@@ -221,5 +221,5 @@ textarea.parsley-error {
 
 /* dashed outline to indicate droppable area */
 .dashed-outline {
-    outline: 2px dashed gray;
+    outline: 4px dashed gray;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -218,3 +218,8 @@ textarea.parsley-error {
 .italic {
     font-style: italic;
 }
+
+/* dashed outline to indicate droppable area */
+.dashed-outline {
+    outline: 2px dashed gray;
+}

--- a/templates/dashboard/contact_detail.html
+++ b/templates/dashboard/contact_detail.html
@@ -43,7 +43,7 @@
             {% endif %}
             <div class="form-group">
               <label class="form-label">PGP Public Key</label>
-              <textarea name="pgp" {% if not current_user.is_premium() %} disabled {% endif %} class="form-control" rows=10 id="pgp-public-key" placeholder="-----BEGIN PGP PUBLIC KEY BLOCK-----">{{ contact.pgp_public_key or "" }}</textarea>
+              <textarea name="pgp" {% if not current_user.is_premium() %} disabled {% endif %} class="form-control dashed-outline" rows=10 id="pgp-public-key" placeholder="(Drag and drop or paste your pgp public key here)&#10;-----BEGIN PGP PUBLIC KEY BLOCK-----">{{ contact.pgp_public_key or "" }}</textarea>
             </div>
             <button class="btn btn-primary" name="action" {% if not current_user.is_premium() %}
                disabled {% endif %} value="save">

--- a/templates/dashboard/contact_detail.html
+++ b/templates/dashboard/contact_detail.html
@@ -43,7 +43,7 @@
             {% endif %}
             <div class="form-group">
               <label class="form-label">PGP Public Key</label>
-              <textarea name="pgp" {% if not current_user.is_premium() %} disabled {% endif %} class="form-control dashed-outline" rows=10 id="pgp-public-key" placeholder="(Drag and drop or paste your pgp public key here)&#10;-----BEGIN PGP PUBLIC KEY BLOCK-----">{{ contact.pgp_public_key or "" }}</textarea>
+              <textarea name="pgp" {% if not current_user.is_premium() %} disabled {% endif %} class="form-control" rows=10 id="pgp-public-key" placeholder="(Drag and drop or paste your pgp public key here)&#10;-----BEGIN PGP PUBLIC KEY BLOCK-----">{{ contact.pgp_public_key or "" }}</textarea>
             </div>
             <button class="btn btn-primary" name="action" {% if not current_user.is_premium() %}
                disabled {% endif %} value="save">

--- a/templates/dashboard/mailbox_detail.html
+++ b/templates/dashboard/mailbox_detail.html
@@ -112,7 +112,7 @@
             {{ csrf_form.csrf_token }}
             <div class="form-group">
               <label class="form-label">PGP Public Key</label>
-              <textarea name="pgp" {% if not current_user.is_premium() %} disabled {% endif %} class="form-control" rows=10 id="pgp-public-key" placeholder="-----BEGIN PGP PUBLIC KEY BLOCK-----">{{ mailbox.pgp_public_key or "" }}</textarea>
+              <textarea name="pgp" {% if not current_user.is_premium() %} disabled {% endif %} class="form-control dashed-outline" rows=10 id="pgp-public-key" placeholder="(Drag and drop or paste your pgp public key here)&#10;-----BEGIN PGP PUBLIC KEY BLOCK-----">{{ mailbox.pgp_public_key or "" }}</textarea>
             </div>
             <input type="hidden" name="form-name" value="pgp">
             <button class="btn btn-primary" name="action" {% if not current_user.is_premium() %}

--- a/templates/dashboard/mailbox_detail.html
+++ b/templates/dashboard/mailbox_detail.html
@@ -112,7 +112,7 @@
             {{ csrf_form.csrf_token }}
             <div class="form-group">
               <label class="form-label">PGP Public Key</label>
-              <textarea name="pgp" {% if not current_user.is_premium() %} disabled {% endif %} class="form-control dashed-outline" rows=10 id="pgp-public-key" placeholder="(Drag and drop or paste your pgp public key here)&#10;-----BEGIN PGP PUBLIC KEY BLOCK-----">{{ mailbox.pgp_public_key or "" }}</textarea>
+              <textarea name="pgp" {% if not current_user.is_premium() %} disabled {% endif %} class="form-control" rows=10 id="pgp-public-key" placeholder="(Drag and drop or paste your pgp public key here)&#10;-----BEGIN PGP PUBLIC KEY BLOCK-----">{{ mailbox.pgp_public_key or "" }}</textarea>
             </div>
             <input type="hidden" name="form-name" value="pgp">
             <button class="btn btn-primary" name="action" {% if not current_user.is_premium() %}


### PR DESCRIPTION
The drag and drop of a PGP public key file only worked on Safari. I added the missing event listeners to also make it work on Firefox and Chromium-based browsers.

For the client side validation of the PGP key file I also tried to verify the file based on its extension, because file.type can give different results based on different browsers' implementations.
For example for a file with the extension `.asc`:
- file.type returns "text/plain" on Safari
- file.type returns "" (empty string) on Firefox and Chromium

So if I didn't change this code:
https://github.com/simple-login/app/blob/66039c526bfeeb4ca60c834fe82337cff6eb9df7/static/js/utils/drag-drop-into-text.js#L11-L12
a user could upload an `.asc` file properly in Safari but would get an error notification on Firefox/Chromium.

Bonus: after a short discussion with @nguyenkims about the UI, I also slightly changed the style of the textarea to make it more explicit that the user can drag and drop their PGP key file there.