### PR TITLE
chore: add example to domain detail with subdomain

### DIFF
--- a/templates/dashboard/domain_detail/dns.html
+++ b/templates/dashboard/domain_detail/dns.html
@@ -266,7 +266,7 @@
           <i>dkim._domainkey.{{ custom_domain.domain }}</i> as domain value instead.
           <br />
           If you are using a subdomain, e.g. <i>subdomain.domain.com</i>,
-          you need to use <i>dkim._domainkey.subdomain</i> as domain value instead.
+          you need to use <i>dkim._domainkey.subdomain</i> as the domain instead.
           <br />
           That means, if your domain is <i>mail.domain.com</i> you should enter <i>dkim._domainkey.mail.domain.com</i> as the Domain.
           <br />


### PR DESCRIPTION
This PR adds an example for clarifying what domain should the user use for the DNS configuration if they are using a subdomain.