### PR TITLE
Change GNUPG home directory variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ DB_URI=postgresql://myuser:mypassword@sl-db:5432/simplelogin
 
 FLASK_SECRET=put_something_secret_here
 
-GNUPGHOME=/sl/pgp
+HOMEDIR=/sl/pgp
 
 LOCAL_FILE_UPLOAD=1
 


### PR DESCRIPTION
In newer versions of gnupg, it uses `homedir` instead of `gnupghome` > https://pythonhosted.org/gnupg/gnupg.html

When using gnupghome in the simplelogin.env I get this error when running the docker command to prepare the database by running the migration:

...... other errors above
  File "/code/app/dashboard/views/mailbox_detail.py", line 20, in <module>
    from app.pgp_utils import PGPException, load_public_key_and_check
  File "/code/app/pgp_utils.py", line 14, in <module>
    gpg = gnupg.GPG(gnupghome=GNUPGHOME)
  File "/usr/local/lib/python3.7/site-packages/gnupg.py", line 827, in __init__
    raise ValueError('gnupghome should be a directory (it isn\'t): %s' % gnupghome)
ValueError: gnupghome should be a directory (it isn't): /sl/pgp

Changing my simplelogin.env to use homedir instead, made this process work. Hope this helps.