### PR TITLE
Add option to show/hide stats in aliases page

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -256,17 +256,27 @@ new Vue({
   el: '#filter-app',
   delimiters: ["[[", "]]"], // necessary to avoid conflict with jinja
   data: {
-    showFilter: false
+    showFilter: false,
+    showStats: false
   },
   methods: {
     async toggleFilter() {
       let that = this;
       that.showFilter = !that.showFilter;
       store.set('showFilter', that.showFilter);
+    },
+
+    async toggleStats() {
+      let that = this;
+      that.showStats = !that.showStats;
+      store.set('showStats', that.showStats);
     }
   },
   async mounted() {
     if (store.get("showFilter"))
       this.showFilter = true;
+
+    if (store.get("showStats"))
+      this.showStats = true;
   }
 });

--- a/templates/dashboard/index.html
+++ b/templates/dashboard/index.html
@@ -31,63 +31,11 @@
 {% block title %}Alias{% endblock %}
 {% block default_content %}
 
-  <!-- Global Stats -->
-  <div class="row">
-    <div class="col-12 col-md-6 col-lg-3">
-      <div class="card">
-        <div class="card-body">
-          <div class="d-flex align-items-center">
-            <div class="subheader">Aliases</div>
-            <div class="text-muted"
-                 style="order: 2; margin-left: auto; font-size: .8rem">All time</div>
-          </div>
-          <div class="h1 m-0">{{ stats.nb_alias }}</div>
-        </div>
-      </div>
-    </div>
-    <div class="col-12 col-md-6 col-lg-3">
-      <div class="card">
-        <div class="card-body">
-          <div class="d-flex align-items-center">
-            <div class="subheader">Forwarded</div>
-            <div class="text-muted"
-                 style="order: 2; margin-left: auto; font-size: .8rem">Last 14 days</div>
-          </div>
-          <div class="h1 m-0">{{ stats.nb_forward }}</div>
-        </div>
-      </div>
-    </div>
-    <div class="col-12 col-md-6 col-lg-3">
-      <div class="card">
-        <div class="card-body">
-          <div class="d-flex align-items-center">
-            <div class="subheader">Replies/Sent</div>
-            <div class="text-muted"
-                 style="order: 2; margin-left: auto; font-size: .8rem">Last 14 days</div>
-          </div>
-          <div class="h1 m-0">{{ stats.nb_reply }}</div>
-        </div>
-      </div>
-    </div>
-    <div class="col-12 col-md-6 col-lg-3">
-      <div class="card">
-        <div class="card-body">
-          <div class="d-flex align-items-center">
-            <div class="subheader">Blocked</div>
-            <div class="text-muted"
-                 style="order: 2; margin-left: auto; font-size: .8rem">Last 14 days</div>
-          </div>
-          <div class="h1 m-0">{{ stats.nb_block }}</div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <!-- END Global Stats -->
   <!-- Controls: buttons & search -->
   <div id="filter-app">
     <div class="row mb-3">
-      <div class="col d-flex">
-        <div>
+      <div class="col d-flex flex-wrap justify-content-between">
+        <div class="mb-1">
           <div class="btn-group" role="group">
             <form method="post">
               {{ csrf_form.csrf_token }}
@@ -141,17 +89,86 @@
             </div>
           </div>
         </div>
-        <div style="margin-left: auto">
+        <div>
           <div class="btn-group">
-            <a v-if="!showFilter"
-               @click="toggleFilter()"
-               class="btn btn-outline-secondary">
-              <i class="fe fe-chevrons-down"></i> Filters
+            <a @click="toggleStats()" class="btn btn-outline-secondary">
+              <span v-if="!showStats">
+                <i class="fe fe-chevrons-down"></i>
+                Show stats
+              </span>
+              <span v-else>
+                <i class="fe fe-chevrons-up"></i>
+                Hide stats
+              </span>
+            </a>
+          </div>
+          <div class="btn-group">
+            <a @click="toggleFilter()" class="btn btn-outline-secondary">
+              <span v-if="!showFilter">
+                <i class="fe fe-chevrons-down"></i>
+                Show filters
+              </span>
+              <span v-else>
+                <i class="fe fe-chevrons-up"></i>
+                Hide filters
+              </span>
             </a>
           </div>
         </div>
       </div>
     </div>
+    <!-- Global Stats -->
+    <div class="row" v-if="showStats">
+      <div class="col-12 col-md-6 col-lg-3">
+        <div class="card mb-3">
+          <div class="card-body py-3">
+            <div class="d-flex align-items-center">
+              <div class="subheader">Aliases</div>
+              <div class="text-muted"
+                   style="order: 2; margin-left: auto; font-size: .8rem">All time</div>
+            </div>
+            <div class="h1 m-0">{{ stats.nb_alias }}</div>
+          </div>
+        </div>
+      </div>
+      <div class="col-12 col-md-6 col-lg-3">
+        <div class="card mb-3">
+          <div class="card-body py-3">
+            <div class="d-flex align-items-center">
+              <div class="subheader">Forwarded</div>
+              <div class="text-muted"
+                   style="order: 2; margin-left: auto; font-size: .8rem">Last 14 days</div>
+            </div>
+            <div class="h1 m-0">{{ stats.nb_forward }}</div>
+          </div>
+        </div>
+      </div>
+      <div class="col-12 col-md-6 col-lg-3">
+        <div class="card mb-3">
+          <div class="card-body py-3">
+            <div class="d-flex align-items-center">
+              <div class="subheader">Replies/Sent</div>
+              <div class="text-muted"
+                   style="order: 2; margin-left: auto; font-size: .8rem">Last 14 days</div>
+            </div>
+            <div class="h1 m-0">{{ stats.nb_reply }}</div>
+          </div>
+        </div>
+      </div>
+      <div class="col-12 col-md-6 col-lg-3">
+        <div class="card mb-3">
+          <div class="card-body py-3">
+            <div class="d-flex align-items-center">
+              <div class="subheader">Blocked</div>
+              <div class="text-muted"
+                   style="order: 2; margin-left: auto; font-size: .8rem">Last 14 days</div>
+            </div>
+            <div class="h1 m-0">{{ stats.nb_block }}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- END Global Stats -->
     <div class="row mb-2" v-if="showFilter" id="filter-control">
       <!-- Filter Control -->
       <div class="col d-flex">
@@ -223,11 +240,6 @@
             <a href="{{ url_for('dashboard.index') }}"
                class="btn btn-outline-secondary">Reset</a>
           {% endif %}
-          <a v-if="showFilter"
-             @click="toggleFilter()"
-             class="btn btn-outline-secondary">
-            <i class="fe fe-chevrons-up"></i>
-          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The stats for aliases (amount, replies/sent etc...) will be hidden by default. They can be shown/hidden by toggling a button and this option is persistent between page refreshes (similar to how the Filters button works).