### PR TITLE
Documentation clarification

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -694,7 +694,7 @@ Return 200 and `existed=true` if contact is already added.
 
 It can return 403 with an error if the user cannot create reverse alias.
 
-``json
+```json
 {
   "error": "Please upgrade to create a reverse-alias"
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,7 +23,7 @@
     <!-- Yandex -->
     <meta name="yandex-verification" content="c9e5d4d68bc983a1" />
     <meta name="description"
-          content="Protect your email address with email ALIAS. Create a different email alias for each website. No more phishing, spams."/>
+          content="Protect your email address with email ALIAS. Create a different email alias for each website. No more phishing, or spam."/>
     <link rel="icon" href="/static/favicon.ico" type="image/x-icon" />
     <link rel="shortcut icon" type="image/x-icon" href="/static/favicon.ico" />
     <link rel="canonical" href="{{ CANONICAL_URL }}" />

--- a/templates/dashboard/refused_email.html
+++ b/templates/dashboard/refused_email.html
@@ -15,7 +15,7 @@
   <div class="col">
     <h1 class="h3 mb-5">Quarantine & Bounce</h1>
     <div class="alert alert-info">
-      This page shows all emails that are either refused by your mailbox (bounced) or detected as spams/phishing (quarantine) via our
+      This page shows all emails that are either refused by your mailbox (bounced) or detected as spam/phishing (quarantine) via our
       <a href="https://simplelogin.io/docs/getting-started/anti-phishing/"
          target="_blank"
          rel="noopener noreferrer">anti-phishing program ↗</a>
@@ -31,7 +31,7 @@
              rel="noopener noreferrer">Setting up filter for SimpleLogin emails ↗</a>
         </li>
         <li>
-          If the email is flagged as spams/phishing, this means that the sender explicitly states their emails should respect
+          If the email is flagged as spam/phishing, this means that the sender explicitly states their emails should respect
           <b>DMARC</b> (an email authentication protocol)
           and any email that violates this should either be quarantined or rejected. If possible, please contact the sender
           so they can update their DMARC setting or fix their SPF/DKIM that cause the DMARC failure.

--- a/templates/emails/transactional/bounce/bounced-email.html
+++ b/templates/emails/transactional/bounce/bounced-email.html
@@ -31,7 +31,7 @@ Please consider the following options:
     <a href="{{ disable_alias_link }}">disable the alias</a>
     or
     <a href="{{ block_sender_link }}">block the sender</a>
-    if they send too many spams.
+    if they send too many spam emails.
   </li>
 </ol>
 <br />

--- a/templates/emails/transactional/bounce/bounced-email.txt.jinja2
+++ b/templates/emails/transactional/bounce/bounced-email.txt.jinja2
@@ -12,7 +12,7 @@ Please consider the following options:
 
 2. If this email is spam, it means your alias {{alias}} is now in the hands of a spammer.
    You can either disable the alias on {{disable_alias_link}}
-   or block the sender on {{ block_sender_link }} if they send too many spams.
+   or block the sender on {{ block_sender_link }} if they send too many spam emails.
 
 Please note that the alias can be automatically disabled if too many emails sent to it are bounced.
 

--- a/templates/notification/bounce-forward-phase.html
+++ b/templates/notification/bounce-forward-phase.html
@@ -19,7 +19,7 @@
       <a href="{{ disable_alias_link }}">disable the alias</a>
       or
       <a href="{{ block_sender_link }}">block the sender</a>
-      if they send too many spams.
+      if they send too many spam emails.
     </li>
   </ol>
 </div>


### PR DESCRIPTION
- Fix a markdown syntax error that prevented a section of the API docs from formatting correctly
- `spam` is an uncountable noun in english - `spams` should not be used, but rather `spam emails` as in 
_"I get many spam emails"_ instead of _"I get many spams"_ or _"They send many spam emails"_ instead of _"They send many spams"_