### PR TITLE
fix: remove user password from export user data

### DIFF
--- a/app/jobs/export_user_data_job.py
+++ b/app/jobs/export_user_data_job.py
@@ -41,7 +41,7 @@ from app.models import (
 class ExportUserDataJob:
 
     REMOVE_FIELDS = {
-        "User": ("otp_secret",),
+        "User": ("otp_secret", "password"),
         "Alias": ("ts_vector", "transfer_token", "hibp_last_check"),
         "CustomDomain": ("ownership_txt_token",),
     }


### PR DESCRIPTION
Add the `password` field to the list of ignored fields during the export of user data. Even though it was hashed, it should not be exported anyways.