### PR TITLE
Documented CAA

### DIFF
--- a/docs/ssl.md
+++ b/docs/ssl.md
@@ -67,7 +67,7 @@ For additional security, we recommend you take some extra steps.
 
 [Certificate Authority Authorization](https://letsencrypt.org/docs/caa/) is a step you can take to restrict the list of certificate authorities that are allowed to issue certificates for your domains.
 
-Create a **CAA record* that contains the following text: 
+Create a **CAA record** that contains the following text: 
 
 To verify if the DNS works, the following command
 

--- a/docs/ssl.md
+++ b/docs/ssl.md
@@ -67,7 +67,11 @@ For additional security, we recommend you take some extra steps.
 
 [Certificate Authority Authorization](https://letsencrypt.org/docs/caa/) is a step you can take to restrict the list of certificate authorities that are allowed to issue certificates for your domains.
 
-Create a **CAA record** that contains the following text: 
+Use [SSLMate’s CAA Record Generator](https://sslmate.com/caa/) to create a **CAA record** with the following configuration:
+
+- `flags`: `0`
+- `tag`: `issue`
+- `value`: `"letsencrypt.org"`
 
 To verify if the DNS works, the following command
 

--- a/docs/ssl.md
+++ b/docs/ssl.md
@@ -1,4 +1,4 @@
-# SSL, HTTPS, and HSTS
+# SSL, HTTPS, HSTS and additional security measures
 
 It's highly recommended to enable SSL/TLS on your server, both for the web app and email server.
 
@@ -57,4 +57,26 @@ Now, reload Nginx:
 
 ```bash
 sudo systemctl reload nginx
+```
+
+## Additional security measures
+
+For additional security, we recommend you take some extra steps.
+
+### Enable Certificate Authority Authorization (CAA)
+
+[Certificate Authority Authorization](https://letsencrypt.org/docs/caa/) is a step you can take to restrict the list of certificate authorities that are allowed to issue certificates for your domains.
+
+Create a **CAA record* that contains the following text: 
+
+To verify if the DNS works, the following command
+
+```bash
+dig @1.1.1.1 mydomain.com caa
+```
+
+should return:
+
+```
+mydomain.com.	3600	IN	CAA	0 issue "letsencrypt.org"
 ```

--- a/docs/ssl.md
+++ b/docs/ssl.md
@@ -75,7 +75,7 @@ Use [SSLMate’s CAA Record Generator](https://sslmate.com/caa/) to create a **C
 
 To verify if the DNS works, the following command
 
-```
+```bash
 dig @1.1.1.1 mydomain.com caa
 ```
 


### PR DESCRIPTION
_This PR adds the following text to the `ssl.md` documentation:_

## Additional security measures

For additional security, we recommend you take some extra steps.

### Enable Certificate Authority Authorization (CAA)

[Certificate Authority Authorization](https://letsencrypt.org/docs/caa/) is a step you can take to restrict the list of certificate authorities that are allowed to issue certificates for your domains.

Create a **CAA record** that contains the following text: 

To verify if the DNS works, the following command

```bash
dig @1.1.1.1 mydomain.com caa
```

should return:

```
mydomain.com.	3600	IN	CAA	0 issue "letsencrypt.org"
```
