### PR TITLE
Fix typo in placeholder text of form on support page

### DIFF
--- a/templates/dashboard/support.html
+++ b/templates/dashboard/support.html
@@ -28,7 +28,7 @@
         <form id="supportZendeskForm" method="post" enctype="multipart/form-data">
           <div class="mt-4 mb-5">
             <label for="issueDescription" class="form-label font-weight-bold">What happened?</label>
-            <textarea class="form-control" required name="ticket_content" id="issueDescription" rows="3" placeholder="Please provide as much information as possible. For example which alias(es), mailbox(es) ar affected, if this is a persistent issue...">{{- ticket_content or '' -}}</textarea>
+            <textarea class="form-control" required name="ticket_content" id="issueDescription" rows="3" placeholder="Please provide as much information as possible. For example which alias(es), mailbox(es) are affected, if this is a persistent issue...">{{- ticket_content or '' -}}</textarea>
           </div>
           <div class="mt-5 font-weight-bold">Attach files to support request</div>
           <div class="text-muted">Only images, text and emails are accepted</div>


### PR DESCRIPTION
"are" was missing an e