### PR TITLE
set debug as False

### DIFF
--- a/oauth_tester.py
+++ b/oauth_tester.py
@@ -85,4 +85,4 @@ os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = "1"
 
 if __name__ == "__main__":
     app.secret_key = os.urandom(24)
-    app.run(debug=True)
+    app.run(debug=False)

--- a/server.py
+++ b/server.py
@@ -904,7 +904,7 @@ def local_main():
     # duration = time.time() - conn.info['query_start_time'].pop(-1)
     # app.config["DEBUG_TB_PANELS"] += ("flask_debugtoolbar_sqlalchemy.SQLAlchemyPanel",)
 
-    app.run(debug=True, port=7777)
+    app.run(debug=False, port=7777)
 
     # uncomment to run https locally
     # LOG.d("enable https")


### PR DESCRIPTION
setting debug as true in production exposes the Werkzeug debugger and allows the execution of arbitrary code