### PR TITLE
fix: handle Proton account not validated case

### DIFF
--- a/app/errors.py
+++ b/app/errors.py
@@ -121,3 +121,10 @@ class AccountAlreadyLinkedToAnotherUserException(LinkException):
 class AccountIsUsingAliasAsEmail(LinkException):
     def __init__(self):
         super().__init__("Your account has an alias as it's email address")
+
+
+class ProtonAccountNotVerified(LinkException):
+    def __init__(self):
+        super().__init__(
+            "The Proton account you are trying to use has not been verified"
+        )


### PR DESCRIPTION
This PR aims to solve a case where the Proton API returns an error indicating that the Proton account is not validated. Right now we're displaying an Internal server error, but this case could be gracefully handled.

With this PR we will now provide a user with a meaningful error message.