### PR TITLE
Update pricing page text

### DIFF
--- a/templates/dashboard/pricing.html
+++ b/templates/dashboard/pricing.html
@@ -207,7 +207,7 @@
                 <div class="card-body">
                   <div class="text-center">
                     <div class="h3">Proton plan</div>
-                    <div class="h3 my-3">Starts at $11.99 / month</div>
+                    <div class="h3 my-3">Starts at $12.99 / month</div>
                     <div class="text-center mt-4 mb-6">
                       <a class="btn btn-lg btn-outline-primary w-100"
                          role="button"
@@ -227,10 +227,6 @@
                     </li>
                     <li class="d-flex">
                       <i class="fe fe-check text-success mr-2 mt-1" aria-hidden="true"></i>
-                      15 email addresses
-                    </li>
-                    <li class="d-flex">
-                      <i class="fe fe-check text-success mr-2 mt-1" aria-hidden="true"></i>
                       Unlimited folders, labels, and filters
                     </li>
                     <li class="d-flex">
@@ -239,11 +235,7 @@
                     </li>
                     <li class="d-flex">
                       <i class="fe fe-check text-success mr-2 mt-1" aria-hidden="true"></i>
-                      15 email addresses
-                    </li>
-                    <li class="d-flex">
-                      <i class="fe fe-check text-success mr-2 mt-1" aria-hidden="true"></i>
-                      20 Calendars
+                      25 calendars
                     </li>
                     <li class="d-flex">
                       <i class="fe fe-check text-success mr-2 mt-1" aria-hidden="true"></i>
@@ -378,10 +370,6 @@
                     </li>
                     <li class="d-flex">
                       <i class="fe fe-check text-success mr-2 mt-1" aria-hidden="true"></i>
-                      15 email addresses/aliases
-                    </li>
-                    <li class="d-flex">
-                      <i class="fe fe-check text-success mr-2 mt-1" aria-hidden="true"></i>
                       Unlimited folders, labels, and filters
                     </li>
                     <li class="d-flex">
@@ -390,11 +378,7 @@
                     </li>
                     <li class="d-flex">
                       <i class="fe fe-check text-success mr-2 mt-1" aria-hidden="true"></i>
-                      15 email addresses/aliases
-                    </li>
-                    <li class="d-flex">
-                      <i class="fe fe-check text-success mr-2 mt-1" aria-hidden="true"></i>
-                      20 Calendars
+                      25 calendars
                     </li>
                     <li class="d-flex">
                       <i class="fe fe-check text-success mr-2 mt-1" aria-hidden="true"></i>


### PR DESCRIPTION
This PR updates information from Proton Unlimited plan (price and amount of calendars) and removes the text "15 email addresses/aliases" as users found it confusing with the text "Unlimited aliases" on the left.