### PR TITLE
Fix: Handle email headers as strings if the are Header type

### DIFF
--- a/app/handler/unsubscribe_generator.py
+++ b/app/handler/unsubscribe_generator.py
@@ -1,4 +1,5 @@
 import urllib
+from email.header import Header
 from email.message import Message
 
 from app.email import headers
@@ -33,6 +34,8 @@ class UnsubscribeGenerator:
         if not unsubscribe_data:
             LOG.info("Email has no unsubscribe header")
             return message
+        if isinstance(unsubscribe_data, Header):
+            unsubscribe_data = str(unsubscribe_data.encode)
         raw_methods = [method.strip() for method in unsubscribe_data.split(",")]
         mailto_unsubs = None
         other_unsubs = []

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -71,7 +71,7 @@ def load_eml_file(
         if not template_values:
             template_values = {}
         rendered = template.render(**template_values)
-        return email.message_from_string(rendered)
+        return email.message_from_bytes(rendered.encode("utf-8"))
 
 
 def random_email() -> str:


### PR DESCRIPTION
Depending on the encoding the headers may come as a string or as a header. Treat them all as strings.