### PR TITLE
Generate working DKIM keys by adding -traditional flag and update NGINX instructions to avoid breaking certbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,8 @@ server {
 }
 ```
 
+Note: If `/etc/nginx/sites-enabled/default` exists, delete it or certbot will fail due to the conflict. The `simplelogin` file should be the only file in `sites-enabled`.
+
 Reload Nginx with the command below
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Setting up DKIM is highly recommended to reduce the chance your emails ending up
 First you need to generate a private and public key for DKIM:
 
 ```bash
-openssl genrsa -out dkim.key 1024
+openssl genrsa -out dkim.key -traditional 1024
 openssl rsa -in dkim.key -pubout -out dkim.pub.key
 ```
 


### PR DESCRIPTION
Add -traditional option to openssl genrsa to avoid Python DKIM library (dkimpy) error that prevents email from being sent:

dkim.asn1.ASN1FormatError: Unexpected tag (got 30, expecting 02)

Ref: https://bugs.launchpad.net/dkimpy/+bug/1708917