### PR TITLE
Fix: Dedup the list of mailboxes for an alias

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1506,7 +1506,8 @@ class Alias(Base, ModelMixin):
     def mailboxes(self):
         ret = [self.mailbox]
         for m in self._mailboxes:
-            ret.append(m)
+            if m.id is not self.mailbox.id:
+                ret.append(m)
 
         ret = [mb for mb in ret if mb.verified]
         ret = sorted(ret, key=lambda mb: mb.email)

--- a/templates/emails/com/onboarding/welcome-proton-user.html
+++ b/templates/emails/com/onboarding/welcome-proton-user.html
@@ -44,9 +44,7 @@ Note, if you are a paying Proton Mail user, you automatically receive the premiu
 
 {% call text() %}
 For any question or feedback, please join our <a href="https://forum.simplelogin.io/">official forum</a>.
-
 If you want to request a feature, please submit it on our <a href="https://github.com/simple-login/app/discussions">GitHub repo</a>.
-
 You can also join our
 <a href="https://www.reddit.com/r/Simplelogin/">Reddit</a>
 or follow our

--- a/templates/emails/com/welcome.html
+++ b/templates/emails/com/welcome.html
@@ -73,10 +73,8 @@ Please note that you can't create more than {{ MAX_NB_EMAIL_FREE_PLAN }} aliases
 {% call text() %}
 For any question or feedback,
 please join our <a href="https://forum.simplelogin.io/">official forum</a>.
-
 If you want to request a feature,
 please submit it on our <a href="https://github.com/simple-login/app/discussions">GitHub repo</a>.
-
 You can also join our
 <a href="https://www.reddit.com/r/Simplelogin/">Reddit</a>
 or follow our

--- a/tests/models/test_alias.py
+++ b/tests/models/test_alias.py
@@ -1,0 +1,17 @@
+from app.db import Session
+from app.models import Alias, Mailbox, AliasMailbox
+from tests.utils import create_new_user, random_email
+
+
+def test_duplicated_mailbox_is_returned_only_once():
+    user = create_new_user()
+    other_mailbox = Mailbox.create(user_id=user.id, email=random_email(), verified=True)
+    alias = Alias.create_new_random(user)
+    AliasMailbox.create(mailbox_id=other_mailbox.id, alias_id=alias.id)
+    AliasMailbox.create(mailbox_id=user.default_mailbox_id, alias_id=alias.id)
+    Session.flush()
+    alias_mailboxes = alias.mailboxes
+    assert len(alias_mailboxes) == 2
+    alias_mailbox_id = [mailbox.id for mailbox in alias_mailboxes]
+    assert user.default_mailbox_id in alias_mailbox_id
+    assert other_mailbox.id in alias_mailbox_id


### PR DESCRIPTION
If the default mailbox for an alias is also in the mailbox alias table, do not return it twice.