### PR TITLE
fix space issue on footer

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -9,7 +9,7 @@
         <a href='https://simplelogin.io/' aria-label="SimpleLogin">
           <img src="/static/logo-white.svg"
                height="30px"
-               class="mb-3"
+               class="mt-1 mb-3"
                alt="SimpleLogin logo">
         </a>
         <!-- End Logo -->


### PR DESCRIPTION
Currently the logo touches the separator

![image](https://github.com/simple-login/app/assets/3167780/8d2311a0-3b74-4f25-9bc0-94fb932768b8)
