### PR TITLE
ci: remove v7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,7 +163,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
 


### PR DESCRIPTION
Remove armv7 from build as poetry seems to error on build

Tested on personal repo

> [linux/arm/v7 stage-1 4/6] RUN pip install -U pip     && apt-get update     && apt install -y curl netcat-traditional gcc python3-dev gnupg git libre2-dev cmake ninja-build    && curl -sSL https://install.python-poetry.org | python3 -     && apt-get purge -y curl netcat-traditional     && poetry config virtualenvs.create false     && poetry install  --no-interaction --no-ansi --no-root     && apt-get purge -y libre2-dev cmake ninja-build    && apt-get clean     && rm -rf /var/lib/apt/lists/*:
89.53 
89.53 You can uninstall at any time by executing this script with the --uninstall option,
89.53 and these changes will be reverted.
89.53 
89.53 Installing Poetry (1.8.2)
89.53 Installing Poetry (1.8.2): Creating environment
145.1 Installing Poetry (1.8.2): Installing Poetry
1664.6 Installing Poetry (1.8.2): An error occurred. Removing partial environment.
1664.7 Poetry installation failed.
1664.7 See /code/poetry-installer-error-hp5ge9u6.log for error logs.