### PR TITLE
fix: event listener

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -3699,7 +3699,10 @@ class SyncEvent(Base, ModelMixin):
           AND taken_time IS NULL
         """
         args = {"taken_time": arrow.now().datetime, "sync_event_id": self.id}
+
         res = Session.execute(sql, args)
+        Session.commit()
+
         return res.rowcount > 0
 
     @classmethod

--- a/event_listener.py
+++ b/event_listener.py
@@ -40,7 +40,7 @@ def main(mode: Mode, dry_run: bool):
         LOG.i("Starting with HttpEventSink")
         sink = HttpEventSink()
 
-    runner = Runner(source=source, sink=sink, force_execution=mode == Mode.DEAD_LETTER)
+    runner = Runner(source=source, sink=sink)
     runner.run()
 
 

--- a/event_listener.py
+++ b/event_listener.py
@@ -40,7 +40,7 @@ def main(mode: Mode, dry_run: bool):
         LOG.i("Starting with HttpEventSink")
         sink = HttpEventSink()
 
-    runner = Runner(source=source, sink=sink)
+    runner = Runner(source=source, sink=sink, force_execution=mode == Mode.DEAD_LETTER)
     runner.run()
 
 

--- a/events/event_source.py
+++ b/events/event_source.py
@@ -65,6 +65,10 @@ class PostgresEventSource(EventSource):
     def __connect(self):
         self.__connection = psycopg2.connect(self.__connection_string)
 
+        from app.db import Session
+
+        Session.close()
+
 
 class DeadLetterEventSource(EventSource):
     @newrelic.agent.background_task()

--- a/events/event_source.py
+++ b/events/event_source.py
@@ -56,7 +56,12 @@ class PostgresEventSource(EventSource):
                         webhook_id = int(notify.payload)
                         event = SyncEvent.get_by(id=webhook_id)
                         if event is not None:
-                            on_event(event)
+                            if event.mark_as_taken():
+                                on_event(event)
+                            else:
+                                LOG.info(
+                                    f"Event {event.id} was handled by another runner"
+                                )
                         else:
                             LOG.info(f"Could not find event with id={notify.payload}")
                     except Exception as e:

--- a/events/event_source.py
+++ b/events/event_source.py
@@ -13,6 +13,8 @@ from typing import Callable, NoReturn
 _DEAD_LETTER_THRESHOLD_MINUTES = 10
 _DEAD_LETTER_INTERVAL_SECONDS = 30
 
+_POSTGRES_RECONNECT_INTERVAL_SECONDS = 5
+
 
 class EventSource(ABC):
     @abstractmethod
@@ -22,9 +24,19 @@ class EventSource(ABC):
 
 class PostgresEventSource(EventSource):
     def __init__(self, connection_string: str):
-        self.__connection = psycopg2.connect(connection_string)
+        self.__connection_string = connection_string
+        self.__connect()
 
     def run(self, on_event: Callable[[SyncEvent], NoReturn]):
+        while True:
+            try:
+                self.__listen(on_event)
+            except Exception as e:
+                LOG.warn(f"Error listening to events: {e}")
+                sleep(_POSTGRES_RECONNECT_INTERVAL_SECONDS)
+                self.__connect()
+
+    def __listen(self, on_event: Callable[[SyncEvent], NoReturn]):
         self.__connection.set_isolation_level(
             psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT
         )
@@ -50,6 +62,9 @@ class PostgresEventSource(EventSource):
                     except Exception as e:
                         LOG.warn(f"Error getting event: {e}")
 
+    def __connect(self):
+        self.__connection = psycopg2.connect(self.__connection_string)
+
 
 class DeadLetterEventSource(EventSource):
     @newrelic.agent.background_task()
@@ -73,3 +88,4 @@ class DeadLetterEventSource(EventSource):
                     sleep(_DEAD_LETTER_INTERVAL_SECONDS)
             except Exception as e:
                 LOG.warn(f"Error getting dead letter event: {e}")
+                sleep(_DEAD_LETTER_INTERVAL_SECONDS)

--- a/events/runner.py
+++ b/events/runner.py
@@ -8,12 +8,9 @@ from events.event_source import EventSource
 
 
 class Runner:
-    def __init__(
-        self, source: EventSource, sink: EventSink, force_execution: bool = False
-    ):
+    def __init__(self, source: EventSource, sink: EventSink):
         self.__source = source
         self.__sink = sink
-        self.__force_execution = force_execution
 
     def run(self):
         self.__source.run(self.__on_event)
@@ -21,31 +18,25 @@ class Runner:
     @newrelic.agent.background_task()
     def __on_event(self, event: SyncEvent):
         try:
-            can_process = event.mark_as_taken()
-            if can_process or self.__force_execution:
-                event_created_at = event.created_at
-                start_time = arrow.now()
-                success = self.__sink.process(event)
-                if success:
-                    event_id = event.id
-                    SyncEvent.delete(event.id, commit=True)
-                    LOG.info(f"Marked {event_id} as done")
+            event_created_at = event.created_at
+            start_time = arrow.now()
+            success = self.__sink.process(event)
+            if success:
+                event_id = event.id
+                SyncEvent.delete(event.id, commit=True)
+                LOG.info(f"Marked {event_id} as done")
 
-                    end_time = arrow.now() - start_time
-                    time_between_taken_and_created = start_time - event_created_at
+                end_time = arrow.now() - start_time
+                time_between_taken_and_created = start_time - event_created_at
 
-                    newrelic.agent.record_custom_metric(
-                        "Custom/sync_event_processed", 1
-                    )
-                    newrelic.agent.record_custom_metric(
-                        "Custom/sync_event_process_time", end_time.total_seconds()
-                    )
-                    newrelic.agent.record_custom_metric(
-                        "Custom/sync_event_elapsed_time",
-                        time_between_taken_and_created.total_seconds(),
-                    )
-            else:
-                LOG.info(f"{event.id} was handled by another runner")
+                newrelic.agent.record_custom_metric("Custom/sync_event_processed", 1)
+                newrelic.agent.record_custom_metric(
+                    "Custom/sync_event_process_time", end_time.total_seconds()
+                )
+                newrelic.agent.record_custom_metric(
+                    "Custom/sync_event_elapsed_time",
+                    time_between_taken_and_created.total_seconds(),
+                )
         except Exception as e:
             LOG.warn(f"Exception processing event [id={event.id}]: {e}")
             newrelic.agent.record_custom_metric("Custom/sync_event_failed", 1)

--- a/events/runner.py
+++ b/events/runner.py
@@ -8,9 +8,12 @@ from events.event_source import EventSource
 
 
 class Runner:
-    def __init__(self, source: EventSource, sink: EventSink):
+    def __init__(
+        self, source: EventSource, sink: EventSink, force_execution: bool = False
+    ):
         self.__source = source
         self.__sink = sink
+        self.__force_execution = force_execution
 
     def run(self):
         self.__source.run(self.__on_event)
@@ -19,7 +22,7 @@ class Runner:
     def __on_event(self, event: SyncEvent):
         try:
             can_process = event.mark_as_taken()
-            if can_process:
+            if can_process or self.__force_execution:
                 event_created_at = event.created_at
                 start_time = arrow.now()
                 success = self.__sink.process(event)


### PR DESCRIPTION
This PR adds some fixes for the event listener:

1. Commits the transaction after marking the event as taken. Otherwise in case of an error it would never add the `taken_time` value.
2. Allows the event_listener to reconnect to postgres, in order to improve resiliency against DB failures.
3. Adds a function to log the sync_events to be processed to the metrics server.
4. Make the `dead_letter` runner able to process events without the `mark_as_taken` returning true, so stuck events can be processed.