### PR TITLE
fix: convert POSTFIX_TIMEOUT to int

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -120,7 +120,7 @@ if POSTFIX_SUBMISSION_TLS:
 else:
     default_postfix_port = 25
 POSTFIX_PORT = int(os.environ.get("POSTFIX_PORT", default_postfix_port))
-POSTFIX_TIMEOUT = os.environ.get("POSTFIX_TIMEOUT", 3)
+POSTFIX_TIMEOUT = int(os.environ.get("POSTFIX_TIMEOUT", 3))
 
 # ["domain1.com", "domain2.com"]
 OTHER_ALIAS_DOMAINS = sl_getenv("OTHER_ALIAS_DOMAINS", list)


### PR DESCRIPTION
When POSTFIX_TIMEOUT reading from env, it's default type is str, which will case an error
This PR converts it to int.