### PR TITLE
chore: allow to define a different DB_URI for event listener

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -596,12 +596,16 @@ def read_webhook_enabled_user_ids() -> Optional[List[int]]:
         return None
 
     ids = []
-    for id in user_ids.split(","):
+    for user_id in user_ids.split(","):
         try:
-            ids.append(int(id.strip()))
+            ids.append(int(user_id.strip()))
         except ValueError:
             pass
     return ids
 
 
 EVENT_WEBHOOK_ENABLED_USER_IDS: Optional[List[int]] = read_webhook_enabled_user_ids()
+
+# Allow to define a different DB_URI for the event listener, in case we want to skip the connection pool
+# It defaults to the regular DB_URI in case it's needed
+EVENT_LISTENER_DB_URI = os.environ.get("EVENT_LISTENER_DB_URI", DB_URI)

--- a/event_listener.py
+++ b/event_listener.py
@@ -2,7 +2,7 @@ import argparse
 from enum import Enum
 from sys import argv, exit
 
-from app.config import DB_URI
+from app.config import EVENT_LISTENER_DB_URI
 from app.log import LOG
 from events.runner import Runner
 from events.event_source import DeadLetterEventSource, PostgresEventSource
@@ -31,7 +31,7 @@ def main(mode: Mode, dry_run: bool, max_retries: int):
         source = DeadLetterEventSource(max_retries)
     elif mode == Mode.LISTENER:
         LOG.i("Using PostgresEventSource")
-        source = PostgresEventSource(DB_URI)
+        source = PostgresEventSource(EVENT_LISTENER_DB_URI)
     else:
         raise ValueError(f"Invalid mode: {mode}")
 

--- a/events/event_source.py
+++ b/events/event_source.py
@@ -46,6 +46,7 @@ class PostgresEventSource(EventSource):
         cursor = self.__connection.cursor()
         cursor.execute(f"LISTEN {NOTIFICATION_CHANNEL};")
 
+        LOG.info("Starting to listen to events")
         while True:
             if select.select([self.__connection], [], [], 5) != ([], [], []):
                 self.__connection.poll()


### PR DESCRIPTION
This MR contains the following changes:

- Allow to configure a different DB_URI for the event listener. If a connection pool DB_URI is used, it may not forward the LISTEN/NOTIFY events properly. It defaults to the `DB_URI` in case it's not needed.
- Replace `id` with `user_id` in a for loop to avoid the linter warning.