### PR TITLE
(feat)Add draft /.well-known/webfinger support (RFC 7033)

### DIFF
--- a/server.py
+++ b/server.py
@@ -335,6 +335,20 @@ def setup_openid_metadata(app):
         res = {"keys": [get_jwk_key()]}
         return jsonify(res)
 
+def discover_openid_webfinger(app):
+    @app.route("/.well-known/webfinger")
+    @cross_origin()
+    def openid_webfinger():
+        res = {
+            "subject": request.args.get(resource),
+            "links": [{
+                    "rel": "http://openid.net/specs/connect/1.0/issuer",
+                    "href": URL
+            },],
+        }
+
+        return jsonify(res)
+
 
 def get_current_user():
     try:


### PR DESCRIPTION
Implement /.well-known/webfinger ([RFC 7033](https://www.rfc-editor.org/rfc/rfc7033#section-3.1).) response as requested in #1927 .

This enables using simplelogin as a provider for tailscale for example.

n.b: this serves as a mere proof of concept and requires tests before merging.

