### PR TITLE
Sync on partner user creation + several fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,7 +109,7 @@ jobs:
           GITHUB_ACTIONS_TEST: true
 
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report
           path: htmlcov

--- a/app/dashboard/views/mailbox.py
+++ b/app/dashboard/views/mailbox.py
@@ -128,7 +128,7 @@ def mailbox_verify():
     except mailbox_utils.MailboxError as e:
         LOG.i(f"Cannot verify mailbox {mailbox_id} because of {e}")
         flash(f"Cannot verify mailbox: {e.msg}", "error")
-        return render_template("dashboard/mailbox_validation.html", mailbox=mailbox)
+        return redirect(url_for("dashboard.mailbox_route"))
     LOG.d("Mailbox %s is verified", mailbox)
     return render_template("dashboard/mailbox_validation.html", mailbox=mailbox)
 

--- a/email_handler.py
+++ b/email_handler.py
@@ -262,8 +262,6 @@ def get_or_create_contact(from_header: str, mail_from: str, alias: Alias) -> Con
 
             Session.commit()
         except IntegrityError:
-            # If the tx has been rolled back, the connection is borked. Force close to try to get a new one and start fresh
-            Session.close()
             LOG.info(
                 f"Contact with email {contact_email} for alias_id {alias_id} already existed, fetching from DB"
             )
@@ -818,7 +816,7 @@ def forward_email_to_mailbox(
 
     email_log = EmailLog.create(
         contact_id=contact.id,
-        user_id=user.id,
+        user_id=contact.user_id,
         mailbox_id=mailbox.id,
         alias_id=contact.alias_id,
         message_id=str(msg[headers.MESSAGE_ID]),

--- a/oneshot/alias_partner_set_flag_and_clear_note.py
+++ b/oneshot/alias_partner_set_flag_and_clear_note.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+import time
+
+from sqlalchemy import func
+from app.models import Alias
+from app.db import Session
+
+parser = argparse.ArgumentParser(
+    prog="Backfill alias", description="Update alias notes and backfill flag"
+)
+parser.add_argument(
+    "-s", "--start_alias_id", default=0, type=int, help="Initial alias_id"
+)
+parser.add_argument("-e", "--end_alias_id", default=0, type=int, help="Last alias_id")
+
+args = parser.parse_args()
+alias_id_start = args.start_alias_id
+max_alias_id = args.end_alias_id
+if max_alias_id == 0:
+    max_alias_id = Session.query(func.max(Alias.id)).scalar()
+
+print(f"Checking alias {alias_id_start} to {max_alias_id}")
+step = 1000
+noteSql = (
+    "(note = 'Created through Proton' or note = 'Created through partner Proton' )"
+)
+el_query = f"SELECT id, note, flags from alias where id>=:start AND id < :end AND {noteSql} ORDER BY id ASC"
+alias_query = f"UPDATE alias set note = NULL, flags = flags | :flag where id = :alias_id and {noteSql}"
+updated = 0
+start_time = time.time()
+for batch_start in range(alias_id_start, max_alias_id, step):
+    rows = Session.execute(el_query, {"start": batch_start, "end": batch_start + step})
+    for row in rows:
+        print(row)
+        sys.exit(1)
+        Session.execute(
+            alias_query, {"alias_id": row[0], "flag": Alias.FLAG_PARTNER_CREATED}
+        )
+        Session.commit()
+        updated += 1
+    elapsed = time.time() - start_time
+    time_per_alias = elapsed / (updated + 1)
+    last_batch_id = batch_start + step
+    remaining = max_alias_id - last_batch_id
+    time_remaining = (max_alias_id - last_batch_id) * time_per_alias
+    hours_remaining = time_remaining / 3600.0
+    print(
+        f"\rAlias {batch_start}/{max_alias_id} {updated} {hours_remaining:.2f}hrs remaining"
+    )
+print("")

--- a/oneshot/alias_partner_set_flag_and_clear_note.py
+++ b/oneshot/alias_partner_set_flag_and_clear_note.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import argparse
-import sys
 import time
 
 from sqlalchemy import func
@@ -33,8 +32,6 @@ start_time = time.time()
 for batch_start in range(alias_id_start, max_alias_id, step):
     rows = Session.execute(el_query, {"start": batch_start, "end": batch_start + step})
     for row in rows:
-        print(row)
-        sys.exit(1)
         Session.execute(
             alias_query, {"alias_id": row[0], "flag": Alias.FLAG_PARTNER_CREATED}
         )


### PR DESCRIPTION
- On new user login/link via partner trigger SL alias initial sync
- Do not close tx on rollback. This leaves dangling user object that fails afterwards
- Redirect to mailbox view instead of rendering the view to avoid requiring an object
- Script to update the alias flag and note once the note is no longer added