### PR TITLE
feat: extract custom domain utils to a service

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -1,1 +1,2 @@
 HEADER_ALLOW_API_COOKIES = "X-Sl-Allowcookies"
+DMARC_RECORD = "v=DMARC1; p=quarantine; pct=100; adkim=s; aspf=s"


### PR DESCRIPTION
This PR performs the following changes:

1. Offer a new function that loads a dictionary from an env var
2. Allow to define partner domains (not in use yet)
3. Extracting logic from the controller into a service so it can be reused
4. Move the DMARC record to `app.constants`