### PR TITLE
Send alias creation in proto

### DIFF
--- a/app/alias_utils.py
+++ b/app/alias_utils.py
@@ -370,9 +370,7 @@ def delete_alias(
 
     EventDispatcher.send_event(
         user,
-        EventContent(
-            alias_deleted=AliasDeleted(alias_id=alias_id, alias_email=alias_email)
-        ),
+        EventContent(alias_deleted=AliasDeleted(id=alias_id, email=alias_email)),
     )
     if commit:
         Session.commit()
@@ -511,7 +509,10 @@ def change_alias_status(alias: Alias, enabled: bool, commit: bool = False):
     alias.enabled = enabled
 
     event = AliasStatusChanged(
-        alias_id=alias.id, alias_email=alias.email, enabled=enabled
+        id=alias.id,
+        email=alias.email,
+        enabled=enabled,
+        created_at=int(alias.created_at.timestamp),
     )
     EventDispatcher.send_event(alias.user, EventContent(alias_status_change=event))
 

--- a/app/events/generated/event_pb2.py
+++ b/app/events/generated/event_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0b\x65vent.proto\x12\x12simplelogin_events\"(\n\x0fUserPlanChanged\x12\x15\n\rplan_end_time\x18\x01 \x01(\r\"\r\n\x0bUserDeleted\"n\n\x0c\x41liasCreated\x12\x10\n\x08\x61lias_id\x18\x01 \x01(\r\x12\x13\n\x0b\x61lias_email\x18\x02 \x01(\t\x12\x12\n\nalias_note\x18\x03 \x01(\t\x12\x0f\n\x07\x65nabled\x18\x04 \x01(\x08\x12\x12\n\ncreated_at\x18\x05 \x01(\r\"L\n\x12\x41liasStatusChanged\x12\x10\n\x08\x61lias_id\x18\x01 \x01(\r\x12\x13\n\x0b\x61lias_email\x18\x02 \x01(\t\x12\x0f\n\x07\x65nabled\x18\x03 \x01(\x08\"5\n\x0c\x41liasDeleted\x12\x10\n\x08\x61lias_id\x18\x01 \x01(\r\x12\x13\n\x0b\x61lias_email\x18\x02 \x01(\t\"D\n\x10\x41liasCreatedList\x12\x30\n\x06\x65vents\x18\x01 \x03(\x0b\x32 .simplelogin_events.AliasCreated\"\x93\x03\n\x0c\x45ventContent\x12?\n\x10user_plan_change\x18\x01 \x01(\x0b\x32#.simplelogin_events.UserPlanChangedH\x00\x12\x37\n\x0cuser_deleted\x18\x02 \x01(\x0b\x32\x1f.simplelogin_events.UserDeletedH\x00\x12\x39\n\ralias_created\x18\x03 \x01(\x0b\x32 .simplelogin_events.AliasCreatedH\x00\x12\x45\n\x13\x61lias_status_change\x18\x04 \x01(\x0b\x32&.simplelogin_events.AliasStatusChangedH\x00\x12\x39\n\ralias_deleted\x18\x05 \x01(\x0b\x32 .simplelogin_events.AliasDeletedH\x00\x12\x41\n\x11\x61lias_create_list\x18\x06 \x01(\x0b\x32$.simplelogin_events.AliasCreatedListH\x00\x42\t\n\x07\x63ontent\"y\n\x05\x45vent\x12\x0f\n\x07user_id\x18\x01 \x01(\r\x12\x18\n\x10\x65xternal_user_id\x18\x02 \x01(\t\x12\x12\n\npartner_id\x18\x03 \x01(\r\x12\x31\n\x07\x63ontent\x18\x04 \x01(\x0b\x32 .simplelogin_events.EventContentb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0b\x65vent.proto\x12\x12simplelogin_events\"(\n\x0fUserPlanChanged\x12\x15\n\rplan_end_time\x18\x01 \x01(\r\"\r\n\x0bUserDeleted\"\\\n\x0c\x41liasCreated\x12\n\n\x02id\x18\x01 \x01(\r\x12\r\n\x05\x65mail\x18\x02 \x01(\t\x12\x0c\n\x04note\x18\x03 \x01(\t\x12\x0f\n\x07\x65nabled\x18\x04 \x01(\x08\x12\x12\n\ncreated_at\x18\x05 \x01(\r\"T\n\x12\x41liasStatusChanged\x12\n\n\x02id\x18\x01 \x01(\r\x12\r\n\x05\x65mail\x18\x02 \x01(\t\x12\x0f\n\x07\x65nabled\x18\x03 \x01(\x08\x12\x12\n\ncreated_at\x18\x04 \x01(\r\")\n\x0c\x41liasDeleted\x12\n\n\x02id\x18\x01 \x01(\r\x12\r\n\x05\x65mail\x18\x02 \x01(\t\"D\n\x10\x41liasCreatedList\x12\x30\n\x06\x65vents\x18\x01 \x03(\x0b\x32 .simplelogin_events.AliasCreated\"\x93\x03\n\x0c\x45ventContent\x12?\n\x10user_plan_change\x18\x01 \x01(\x0b\x32#.simplelogin_events.UserPlanChangedH\x00\x12\x37\n\x0cuser_deleted\x18\x02 \x01(\x0b\x32\x1f.simplelogin_events.UserDeletedH\x00\x12\x39\n\ralias_created\x18\x03 \x01(\x0b\x32 .simplelogin_events.AliasCreatedH\x00\x12\x45\n\x13\x61lias_status_change\x18\x04 \x01(\x0b\x32&.simplelogin_events.AliasStatusChangedH\x00\x12\x39\n\ralias_deleted\x18\x05 \x01(\x0b\x32 .simplelogin_events.AliasDeletedH\x00\x12\x41\n\x11\x61lias_create_list\x18\x06 \x01(\x0b\x32$.simplelogin_events.AliasCreatedListH\x00\x42\t\n\x07\x63ontent\"y\n\x05\x45vent\x12\x0f\n\x07user_id\x18\x01 \x01(\r\x12\x18\n\x10\x65xternal_user_id\x18\x02 \x01(\t\x12\x12\n\npartner_id\x18\x03 \x01(\r\x12\x31\n\x07\x63ontent\x18\x04 \x01(\x0b\x32 .simplelogin_events.EventContentb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -36,15 +36,15 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_USERDELETED']._serialized_start=77
   _globals['_USERDELETED']._serialized_end=90
   _globals['_ALIASCREATED']._serialized_start=92
-  _globals['_ALIASCREATED']._serialized_end=202
-  _globals['_ALIASSTATUSCHANGED']._serialized_start=204
-  _globals['_ALIASSTATUSCHANGED']._serialized_end=280
-  _globals['_ALIASDELETED']._serialized_start=282
-  _globals['_ALIASDELETED']._serialized_end=335
-  _globals['_ALIASCREATEDLIST']._serialized_start=337
-  _globals['_ALIASCREATEDLIST']._serialized_end=405
-  _globals['_EVENTCONTENT']._serialized_start=408
-  _globals['_EVENTCONTENT']._serialized_end=811
-  _globals['_EVENT']._serialized_start=813
-  _globals['_EVENT']._serialized_end=934
+  _globals['_ALIASCREATED']._serialized_end=184
+  _globals['_ALIASSTATUSCHANGED']._serialized_start=186
+  _globals['_ALIASSTATUSCHANGED']._serialized_end=270
+  _globals['_ALIASDELETED']._serialized_start=272
+  _globals['_ALIASDELETED']._serialized_end=313
+  _globals['_ALIASCREATEDLIST']._serialized_start=315
+  _globals['_ALIASCREATEDLIST']._serialized_end=383
+  _globals['_EVENTCONTENT']._serialized_start=386
+  _globals['_EVENTCONTENT']._serialized_end=789
+  _globals['_EVENT']._serialized_start=791
+  _globals['_EVENT']._serialized_end=912
 # @@protoc_insertion_point(module_scope)

--- a/app/events/generated/event_pb2.pyi
+++ b/app/events/generated/event_pb2.pyi
@@ -16,36 +16,38 @@ class UserDeleted(_message.Message):
     def __init__(self) -> None: ...
 
 class AliasCreated(_message.Message):
-    __slots__ = ("alias_id", "alias_email", "alias_note", "enabled", "created_at")
-    ALIAS_ID_FIELD_NUMBER: _ClassVar[int]
-    ALIAS_EMAIL_FIELD_NUMBER: _ClassVar[int]
-    ALIAS_NOTE_FIELD_NUMBER: _ClassVar[int]
+    __slots__ = ("id", "email", "note", "enabled", "created_at")
+    ID_FIELD_NUMBER: _ClassVar[int]
+    EMAIL_FIELD_NUMBER: _ClassVar[int]
+    NOTE_FIELD_NUMBER: _ClassVar[int]
     ENABLED_FIELD_NUMBER: _ClassVar[int]
     CREATED_AT_FIELD_NUMBER: _ClassVar[int]
-    alias_id: int
-    alias_email: str
-    alias_note: str
+    id: int
+    email: str
+    note: str
     enabled: bool
     created_at: int
-    def __init__(self, alias_id: _Optional[int] = ..., alias_email: _Optional[str] = ..., alias_note: _Optional[str] = ..., enabled: bool = ..., created_at: _Optional[int] = ...) -> None: ...
+    def __init__(self, id: _Optional[int] = ..., email: _Optional[str] = ..., note: _Optional[str] = ..., enabled: bool = ..., created_at: _Optional[int] = ...) -> None: ...
 
 class AliasStatusChanged(_message.Message):
-    __slots__ = ("alias_id", "alias_email", "enabled")
-    ALIAS_ID_FIELD_NUMBER: _ClassVar[int]
-    ALIAS_EMAIL_FIELD_NUMBER: _ClassVar[int]
+    __slots__ = ("id", "email", "enabled", "created_at")
+    ID_FIELD_NUMBER: _ClassVar[int]
+    EMAIL_FIELD_NUMBER: _ClassVar[int]
     ENABLED_FIELD_NUMBER: _ClassVar[int]
-    alias_id: int
-    alias_email: str
+    CREATED_AT_FIELD_NUMBER: _ClassVar[int]
+    id: int
+    email: str
     enabled: bool
-    def __init__(self, alias_id: _Optional[int] = ..., alias_email: _Optional[str] = ..., enabled: bool = ...) -> None: ...
+    created_at: int
+    def __init__(self, id: _Optional[int] = ..., email: _Optional[str] = ..., enabled: bool = ..., created_at: _Optional[int] = ...) -> None: ...
 
 class AliasDeleted(_message.Message):
-    __slots__ = ("alias_id", "alias_email")
-    ALIAS_ID_FIELD_NUMBER: _ClassVar[int]
-    ALIAS_EMAIL_FIELD_NUMBER: _ClassVar[int]
-    alias_id: int
-    alias_email: str
-    def __init__(self, alias_id: _Optional[int] = ..., alias_email: _Optional[str] = ...) -> None: ...
+    __slots__ = ("id", "email")
+    ID_FIELD_NUMBER: _ClassVar[int]
+    EMAIL_FIELD_NUMBER: _ClassVar[int]
+    id: int
+    email: str
+    def __init__(self, id: _Optional[int] = ..., email: _Optional[str] = ...) -> None: ...
 
 class AliasCreatedList(_message.Message):
     __slots__ = ("events",)

--- a/app/jobs/event_jobs.py
+++ b/app/jobs/event_jobs.py
@@ -22,10 +22,11 @@ def send_alias_creation_events_for_user(
     ):
         event_list.append(
             AliasCreated(
-                alias_id=alias.id,
-                alias_email=alias.email,
-                alias_note=alias.note,
+                id=alias.id,
+                email=alias.email,
+                note=alias.note,
                 enabled=alias.enabled,
+                created_at=int(alias.created_at.timestamp),
             )
         )
         if len(event_list) >= chunk_size:

--- a/app/models.py
+++ b/app/models.py
@@ -1677,9 +1677,9 @@ class Alias(Base, ModelMixin):
         from app.events.generated.event_pb2 import AliasCreated, EventContent
 
         event = AliasCreated(
-            alias_id=new_alias.id,
-            alias_email=new_alias.email,
-            alias_note=new_alias.note,
+            id=new_alias.id,
+            email=new_alias.email,
+            note=new_alias.note,
             enabled=True,
             created_at=int(new_alias.created_at.timestamp),
         )

--- a/proto/event.proto
+++ b/proto/event.proto
@@ -10,22 +10,23 @@ message UserDeleted {
 }
 
 message AliasCreated {
-  uint32 alias_id = 1;
-  string alias_email = 2;
-  string alias_note = 3;
+  uint32 id = 1;
+  string email = 2;
+  string note = 3;
   bool enabled = 4;
   uint32 created_at = 5;
 }
 
 message AliasStatusChanged {
-  uint32 alias_id = 1;
-  string alias_email = 2;
+  uint32 id = 1;
+  string email = 2;
   bool enabled = 3;
+  uint32 created_at = 4;
 }
 
 message AliasDeleted {
-  uint32 alias_id = 1;
-  string alias_email = 2;
+  uint32 id = 1;
+  string email = 2;
 }
 
 message AliasCreatedList {

--- a/tests/events/test_sent_events.py
+++ b/tests/events/test_sent_events.py
@@ -46,9 +46,9 @@ def test_fire_event_on_alias_creation():
     event_content = _get_event_from_string(event_data, user, pu)
     assert event_content.alias_created is not None
     alias_created = event_content.alias_created
-    assert alias.id == alias_created.alias_id
-    assert alias.email == alias_created.alias_email
-    assert "" == alias_created.alias_note
+    assert alias.id == alias_created.id
+    assert alias.email == alias_created.email
+    assert "" == alias_created.note
     assert alias.enabled == alias_created.enabled
     assert int(alias.created_at.timestamp) == alias_created.created_at
 
@@ -63,9 +63,9 @@ def test_fire_event_on_alias_creation_with_note():
     event_content = _get_event_from_string(event_data, user, pu)
     assert event_content.alias_created is not None
     alias_created = event_content.alias_created
-    assert alias.id == alias_created.alias_id
-    assert alias.email == alias_created.alias_email
-    assert note == alias_created.alias_note
+    assert alias.id == alias_created.id
+    assert alias.email == alias_created.email
+    assert note == alias_created.note
     assert alias.enabled == alias_created.enabled
 
 
@@ -81,8 +81,8 @@ def test_fire_event_on_alias_deletion():
     event_content = _get_event_from_string(event_data, user, pu)
     assert event_content.alias_deleted is not None
     alias_deleted = event_content.alias_deleted
-    assert alias_id == alias_deleted.alias_id
-    assert alias.email == alias_deleted.alias_email
+    assert alias_id == alias_deleted.id
+    assert alias.email == alias_deleted.email
 
 
 def test_fire_event_on_alias_status_change():
@@ -96,6 +96,7 @@ def test_fire_event_on_alias_status_change():
     event_content = _get_event_from_string(event_data, user, pu)
     assert event_content.alias_status_change is not None
     event = event_content.alias_status_change
-    assert alias.id == event.alias_id
-    assert alias.email == event.alias_email
+    assert alias.id == event.id
+    assert alias.email == event.email
+    assert int(alias.created_at.timestamp) == event.created_at
     assert event.enabled

--- a/tests/jobs/test_send_alias_creation_events.py
+++ b/tests/jobs/test_send_alias_creation_events.py
@@ -37,10 +37,14 @@ def test_send_alias_creation_events():
     event_list = decoded_event.content.alias_create_list.events
     assert len(event_list) == 2
     # 0 is newsletter alias
-    assert event_list[1].alias_id == aliases[0].id
+    assert event_list[1].id == aliases[0].id
+    assert event_list[1].email == aliases[0].email
+    assert event_list[1].note == ""
+    assert event_list[1].enabled == aliases[0].enabled
+    assert event_list[1].created_at == int(aliases[0].created_at.timestamp)
     decoded_event = event_pb2.Event.FromString(dispatcher.events[1])
     assert decoded_event.user_id == user.id
     assert decoded_event.external_user_id == partner_user.external_user_id
     event_list = decoded_event.content.alias_create_list.events
     assert len(event_list) == 1
-    assert event_list[0].alias_id == aliases[1].id
+    assert event_list[0].id == aliases[1].id


### PR DESCRIPTION
Also. homogeneized the names of the proto events. Some had `alias_` and some didn't. Since the events are all `AliasSomething` I've removed the `alias_` prefix where it was redundant