### PR TITLE
feat: allow to define partner records

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -638,19 +638,22 @@ EVENT_WEBHOOK_ENABLED_USER_IDS: Optional[List[int]] = read_webhook_enabled_user_
 EVENT_LISTENER_DB_URI = os.environ.get("EVENT_LISTENER_DB_URI", DB_URI)
 
 
-def read_partner_domains() -> dict[int, str]:
-    partner_domains_dict = get_env_dict("PARTNER_DOMAINS")
-    if len(partner_domains_dict) == 0:
+def read_partner_dict(var: str) -> dict[int, str]:
+    partner_value = get_env_dict(var)
+    if len(partner_value) == 0:
         return {}
 
     res: dict[int, str] = {}
-    for partner_id in partner_domains_dict.keys():
+    for partner_id in partner_value.keys():
         try:
             partner_id_int = int(partner_id.strip())
-            res[partner_id_int] = partner_domains_dict[partner_id]
+            res[partner_id_int] = partner_value[partner_id]
         except ValueError:
             pass
     return res
 
 
-PARTNER_DOMAINS: dict[int, str] = read_partner_domains()
+PARTNER_DOMAINS: dict[int, str] = read_partner_dict("PARTNER_DOMAINS")
+PARTNER_DOMAIN_VALIDATION_PREFIXES: dict[int, str] = read_partner_dict(
+    "PARTNER_DOMAIN_VALIDATION_PREFIXES"
+)

--- a/app/dashboard/views/domain_detail.py
+++ b/app/dashboard/views/domain_detail.py
@@ -141,7 +141,10 @@ def domain_detail_dns(custom_domain_id):
     return render_template(
         "dashboard/domain_detail/dns.html",
         EMAIL_SERVERS_WITH_PRIORITY=EMAIL_SERVERS_WITH_PRIORITY,
-        dkim_records=domain_validator.get_dkim_records(),
+        ownership_record=domain_validator.get_ownership_verification_record(
+            custom_domain
+        ),
+        dkim_records=domain_validator.get_dkim_records(custom_domain),
         dmarc_record=DMARC_RECORD,
         **locals(),
     )

--- a/app/models.py
+++ b/app/models.py
@@ -2451,9 +2451,6 @@ class CustomDomain(Base, ModelMixin):
     def get_trash_url(self):
         return config.URL + f"/dashboard/domains/{self.id}/trash"
 
-    def get_ownership_dns_txt_value(self):
-        return f"sl-verification={self.ownership_txt_token}"
-
     @classmethod
     def create(cls, **kwargs):
         domain = kwargs.get("domain")

--- a/templates/dashboard/domain_detail/dns.html
+++ b/templates/dashboard/domain_detail/dns.html
@@ -38,7 +38,7 @@
             Value: <em data-toggle="tooltip"
      title="Click to copy"
      class="clipboard"
-     data-clipboard-text="{{ custom_domain.get_ownership_dns_txt_value() }}">{{ custom_domain.get_ownership_dns_txt_value() }}</em>
+     data-clipboard-text="{{ ownership_record }}">{{ ownership_record }}</em>
           </div>
           <form method="post" action="#ownership-form">
             {{ csrf_form.csrf_token }}


### PR DESCRIPTION
This PR adds the ability to define partner records and prefixes for custom domain validation.
It perorms the following changes:

1. Extract the `get_ownership_dns_txt_value` function from the model into a function of the `CustomDomainValidation`.
2. Remove the direct call from the template to the aforementioned function in order to pass the value from the controller.
3. Add the new configs that define the domain and the verification prefix for each partner.
4. Use these configs in the CustomDomainValidation, with fallbacks for the existing behaviour.