### PR TITLE
Add monitoring for app connections to the db

### DIFF
--- a/events/event_source.py
+++ b/events/event_source.py
@@ -72,7 +72,9 @@ class PostgresEventSource(EventSource):
                     Session.close()  # Ensure we get a new connection and we don't leave a dangling tx
 
     def __connect(self):
-        self.__connection = psycopg2.connect(self.__connection_string)
+        self.__connection = psycopg2.connect(
+            self.__connection_string, application_name="sl-event-listen"
+        )
 
         from app.db import Session
 


### PR DESCRIPTION
To restrict possible values we restrict app names that start with `sl-`