### PR TITLE
feat: allow override mailbox verification code

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -657,3 +657,7 @@ PARTNER_DOMAINS: dict[int, str] = read_partner_dict("PARTNER_DOMAINS")
 PARTNER_DOMAIN_VALIDATION_PREFIXES: dict[int, str] = read_partner_dict(
     "PARTNER_DOMAIN_VALIDATION_PREFIXES"
 )
+
+MAILBOX_VERIFICATION_OVERRIDE_CODE: Optional[str] = os.environ.get(
+    "MAILBOX_VERIFICATION_OVERRIDE_CODE", None
+)

--- a/app/mailbox_utils.py
+++ b/app/mailbox_utils.py
@@ -212,7 +212,9 @@ def generate_activation_code(
     mailbox: Mailbox, use_digit_code: bool = False
 ) -> MailboxActivation:
     clear_activation_codes_for_mailbox(mailbox)
-    if use_digit_code:
+    if config.MAILBOX_VERIFICATION_OVERRIDE_CODE:
+        code = config.MAILBOX_VERIFICATION_OVERRIDE_CODE
+    elif use_digit_code:
         code = "{:06d}".format(random.randint(1, 999999))
     else:
         code = secrets.token_urlsafe(16)


### PR DESCRIPTION
This PR adds a useful feature for testing environments, so we can predefine a static mailbox verification code via config. If not defined, the behaviour will match the previously existing one.