### PR TITLE
fix: improve MX and SPF domain handling

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -653,9 +653,11 @@ def read_partner_dict(var: str) -> dict[int, str]:
     return res
 
 
-PARTNER_DOMAINS: dict[int, str] = read_partner_dict("PARTNER_DOMAINS")
-PARTNER_DOMAIN_VALIDATION_PREFIXES: dict[int, str] = read_partner_dict(
-    "PARTNER_DOMAIN_VALIDATION_PREFIXES"
+PARTNER_DNS_CUSTOM_DOMAINS: dict[int, str] = read_partner_dict(
+    "PARTNER_DNS_CUSTOM_DOMAINS"
+)
+PARTNER_CUSTOM_DOMAIN_VALIDATION_PREFIXES: dict[int, str] = read_partner_dict(
+    "PARTNER_CUSTOM_DOMAIN_VALIDATION_PREFIXES"
 )
 
 MAILBOX_VERIFICATION_OVERRIDE_CODE: Optional[str] = os.environ.get(

--- a/app/custom_domain_validation.py
+++ b/app/custom_domain_validation.py
@@ -29,10 +29,10 @@ class CustomDomainValidation:
     ):
         self.dkim_domain = dkim_domain
         self._dns_client = dns_client
-        self._partner_domains = partner_domains or config.PARTNER_DOMAINS
+        self._partner_domains = partner_domains or config.PARTNER_DNS_CUSTOM_DOMAINS
         self._partner_domain_validation_prefixes = (
             partner_domains_validation_prefixes
-            or config.PARTNER_DOMAIN_VALIDATION_PREFIXES
+            or config.PARTNER_CUSTOM_DOMAIN_VALIDATION_PREFIXES
         )
 
     def get_ownership_verification_record(self, domain: CustomDomain) -> str:

--- a/app/custom_domain_validation.py
+++ b/app/custom_domain_validation.py
@@ -181,7 +181,3 @@ class CustomDomainValidation:
             custom_domain.dmarc_verified = False
             Session.commit()
             return DomainValidationResult(success=False, errors=txt_records)
-
-    @staticmethod
-    def get_instance() -> "CustomDomainValidation":
-        return CustomDomainValidation(dkim_domain=config.EMAIL_DOMAIN)

--- a/app/custom_domain_validation.py
+++ b/app/custom_domain_validation.py
@@ -5,6 +5,7 @@ from app import config
 from app.constants import DMARC_RECORD
 from app.db import Session
 from app.dns_utils import (
+    MxRecord,
     DNSClient,
     is_mx_equivalent,
     get_network_dns_client,
@@ -42,6 +43,29 @@ class CustomDomainValidation:
         ):
             prefix = self._partner_domain_validation_prefixes[domain.partner_id]
         return f"{prefix}-verification={domain.ownership_txt_token}"
+
+    def get_expected_mx_records(self, domain: CustomDomain) -> list[MxRecord]:
+        records = []
+        if domain.partner_id is not None and domain.partner_id in self._partner_domains:
+            domain = self._partner_domains[domain.partner_id]
+            records.append(MxRecord(10, f"mx1.{domain}."))
+            records.append(MxRecord(20, f"mx2.{domain}."))
+        else:
+            # Default ones
+            for priority, domain in config.EMAIL_SERVERS_WITH_PRIORITY:
+                records.append(MxRecord(priority, domain))
+
+        return records
+
+    def get_expected_spf_domain(self, domain: CustomDomain) -> str:
+        if domain.partner_id is not None and domain.partner_id in self._partner_domains:
+            return self._partner_domains[domain.partner_id]
+        else:
+            return config.EMAIL_DOMAIN
+
+    def get_expected_spf_record(self, domain: CustomDomain) -> str:
+        spf_domain = self.get_expected_spf_domain(domain)
+        return f"v=spf1 include:{spf_domain} ~all"
 
     def get_dkim_records(self, domain: CustomDomain) -> {str: str}:
         """
@@ -116,11 +140,12 @@ class CustomDomainValidation:
         self, custom_domain: CustomDomain
     ) -> DomainValidationResult:
         mx_domains = self._dns_client.get_mx_domains(custom_domain.domain)
+        expected_mx_records = self.get_expected_mx_records(custom_domain)
 
-        if not is_mx_equivalent(mx_domains, config.EMAIL_SERVERS_WITH_PRIORITY):
+        if not is_mx_equivalent(mx_domains, expected_mx_records):
             return DomainValidationResult(
                 success=False,
-                errors=[f"{priority} {domain}" for (priority, domain) in mx_domains],
+                errors=[f"{record.priority} {record.domain}" for record in mx_domains],
             )
         else:
             custom_domain.verified = True
@@ -131,7 +156,8 @@ class CustomDomainValidation:
         self, custom_domain: CustomDomain
     ) -> DomainValidationResult:
         spf_domains = self._dns_client.get_spf_domain(custom_domain.domain)
-        if config.EMAIL_DOMAIN in spf_domains:
+        expected_spf_domain = self.get_expected_spf_domain(custom_domain)
+        if expected_spf_domain in spf_domains:
             custom_domain.spf_verified = True
             Session.commit()
             return DomainValidationResult(success=True, errors=[])
@@ -155,3 +181,7 @@ class CustomDomainValidation:
             custom_domain.dmarc_verified = False
             Session.commit()
             return DomainValidationResult(success=False, errors=txt_records)
+
+    @staticmethod
+    def get_instance() -> "CustomDomainValidation":
+        return CustomDomainValidation(dkim_domain=config.EMAIL_DOMAIN)

--- a/app/dashboard/views/domain_detail.py
+++ b/app/dashboard/views/domain_detail.py
@@ -36,8 +36,6 @@ def domain_detail_dns(custom_domain_id):
         custom_domain.ownership_txt_token = random_string(30)
         Session.commit()
 
-    spf_record = f"v=spf1 include:{EMAIL_DOMAIN} ~all"
-
     domain_validator = CustomDomainValidation(EMAIL_DOMAIN)
     csrf_form = CSRFValidationForm()
 
@@ -141,7 +139,9 @@ def domain_detail_dns(custom_domain_id):
         ownership_record=domain_validator.get_ownership_verification_record(
             custom_domain
         ),
+        expected_mx_records=domain_validator.get_expected_mx_records(custom_domain),
         dkim_records=domain_validator.get_dkim_records(custom_domain),
+        spf_record=domain_validator.get_expected_spf_record(custom_domain),
         dmarc_record=DMARC_RECORD,
         **locals(),
     )

--- a/app/email_utils.py
+++ b/app/email_utils.py
@@ -657,7 +657,7 @@ def get_mx_domain_list(domain) -> [str]:
     """
     priority_domains = get_mx_domains(domain)
 
-    return [d[:-1] for _, d in priority_domains]
+    return [d.domain[:-1] for d in priority_domains]
 
 
 def personal_email_already_used(email_address: str) -> bool:

--- a/app/models.py
+++ b/app/models.py
@@ -2766,9 +2766,9 @@ class Mailbox(Base, ModelMixin):
 
         from app.email_utils import get_email_local_part
 
-        mx_domains: [(int, str)] = get_mx_domains(get_email_local_part(self.email))
+        mx_domains = get_mx_domains(get_email_local_part(self.email))
         # Proton is the first domain
-        if mx_domains and mx_domains[0][1] in (
+        if mx_domains and mx_domains[0].domain in (
             "mail.protonmail.ch.",
             "mailsec.protonmail.ch.",
         ):

--- a/cron.py
+++ b/cron.py
@@ -14,6 +14,7 @@ from sqlalchemy.sql import Insert, text
 from app import s3, config
 from app.alias_utils import nb_email_log_for_mailbox
 from app.api.views.apple import verify_receipt
+from app.custom_domain_validation import CustomDomainValidation
 from app.db import Session
 from app.dns_utils import get_mx_domains, is_mx_equivalent
 from app.email_utils import (
@@ -905,9 +906,11 @@ def check_custom_domain():
             LOG.i("custom domain has been deleted")
 
 
-def check_single_custom_domain(custom_domain):
+def check_single_custom_domain(custom_domain: CustomDomain):
     mx_domains = get_mx_domains(custom_domain.domain)
-    if not is_mx_equivalent(mx_domains, config.EMAIL_SERVERS_WITH_PRIORITY):
+    validator = CustomDomainValidation.get_instance()
+    expected_custom_domains = validator.get_expected_mx_records(custom_domain)
+    if not is_mx_equivalent(mx_domains, expected_custom_domains):
         user = custom_domain.user
         LOG.w(
             "The MX record is not correctly set for %s %s %s",

--- a/cron.py
+++ b/cron.py
@@ -908,7 +908,7 @@ def check_custom_domain():
 
 def check_single_custom_domain(custom_domain: CustomDomain):
     mx_domains = get_mx_domains(custom_domain.domain)
-    validator = CustomDomainValidation.get_instance()
+    validator = CustomDomainValidation(dkim_domain=config.EMAIL_DOMAIN)
     expected_custom_domains = validator.get_expected_mx_records(custom_domain)
     if not is_mx_equivalent(mx_domains, expected_custom_domains):
         user = custom_domain.user

--- a/templates/dashboard/domain_detail/dns.html
+++ b/templates/dashboard/domain_detail/dns.html
@@ -91,7 +91,8 @@
           <br />
           Some domain registrars (Namecheap, CloudFlare, etc) might also use <em>@</em> for the root domain.
         </div>
-        {% for priority, email_server in EMAIL_SERVERS_WITH_PRIORITY %}
+
+        {% for record in expected_mx_records %}
 
           <div class="mb-3 p-3 dns-record">
             Record: MX
@@ -99,14 +100,15 @@
             Domain: {{ custom_domain.domain }} or
             <b>@</b>
             <br />
-            Priority: {{ priority }}
+            Priority: {{ record.priority }}
             <br />
             Target: <em data-toggle="tooltip"
      title="Click to copy"
      class="clipboard"
-     data-clipboard-text="{{ email_server }}">{{ email_server }}</em>
+     data-clipboard-text="{{ record.domain }}">{{ record.domain }}</em>
           </div>
         {% endfor %}
+
         <form method="post" action="#mx-form">
           {{ csrf_form.csrf_token }}
           <input type="hidden" name="form-name" value="check-mx">

--- a/tests/test_dns_utils.py
+++ b/tests/test_dns_utils.py
@@ -3,6 +3,7 @@ from app.dns_utils import (
     get_network_dns_client,
     is_mx_equivalent,
     InMemoryDNSClient,
+    MxRecord,
 )
 
 from tests.utils import random_domain
@@ -17,8 +18,8 @@ def test_get_mx_domains():
     assert len(r) > 0
 
     for x in r:
-        assert x[0] > 0
-        assert x[1]
+        assert x.priority > 0
+        assert x.domain
 
 
 def test_get_spf_domain():
@@ -33,20 +34,32 @@ def test_get_txt_record():
 
 def test_is_mx_equivalent():
     assert is_mx_equivalent([], [])
-    assert is_mx_equivalent([(1, "domain")], [(1, "domain")])
     assert is_mx_equivalent(
-        [(10, "domain1"), (20, "domain2")], [(10, "domain1"), (20, "domain2")]
+        mx_domains=[MxRecord(1, "domain")], ref_mx_domains=[MxRecord(1, "domain")]
     )
     assert is_mx_equivalent(
-        [(5, "domain1"), (10, "domain2")], [(10, "domain1"), (20, "domain2")]
+        mx_domains=[MxRecord(10, "domain1"), MxRecord(20, "domain2")],
+        ref_mx_domains=[MxRecord(10, "domain1"), MxRecord(20, "domain2")],
     )
     assert is_mx_equivalent(
-        [(5, "domain1"), (10, "domain2"), (20, "domain3")],
-        [(10, "domain1"), (20, "domain2")],
+        mx_domains=[MxRecord(5, "domain1"), MxRecord(10, "domain2")],
+        ref_mx_domains=[MxRecord(10, "domain1"), MxRecord(20, "domain2")],
+    )
+    assert is_mx_equivalent(
+        mx_domains=[
+            MxRecord(5, "domain1"),
+            MxRecord(10, "domain2"),
+            MxRecord(20, "domain3"),
+        ],
+        ref_mx_domains=[MxRecord(10, "domain1"), MxRecord(20, "domain2")],
     )
     assert not is_mx_equivalent(
-        [(5, "domain1"), (10, "domain2")],
-        [(10, "domain1"), (20, "domain2"), (20, "domain3")],
+        mx_domains=[MxRecord(5, "domain1"), MxRecord(10, "domain2")],
+        ref_mx_domains=[
+            MxRecord(10, "domain1"),
+            MxRecord(20, "domain2"),
+            MxRecord(20, "domain3"),
+        ],
     )
 
 


### PR DESCRIPTION
⚠️ Please review with attention ⚠️ 

This PR performs the following changes:

1. Move out logic from the `dns.html` template file into the controller, passing the values to be used instead of calculating them in the template.
2. Offer new functions that return the expected MX and SPF records on the `CustomDomainValidation` class.
3. Make use of the aforementioned functions during the MX and SPF verification process.
4. Encapsulate the MX records into a `MxRecord` class instead of a `Tuple[int, str]`. 
5. Adapt the tests accordingly to these changes and add some new ones.