### PR TITLE
chore: DNS validation improvements

### DIFF
--- a/app/custom_domain_validation.py
+++ b/app/custom_domain_validation.py
@@ -186,22 +186,9 @@ class CustomDomainValidation:
             Session.commit()
             return DomainValidationResult(success=True, errors=[])
         else:
-            cleaned_records = self.__clean_dmarc_records(txt_records, custom_domain)
             custom_domain.dmarc_verified = False
             Session.commit()
-            return DomainValidationResult(success=False, errors=cleaned_records)
-
-    def __clean_dmarc_records(
-        self, txt_records: List[str], custom_domain: CustomDomain
-    ) -> List[str]:
-        final_records = []
-        verification_record = self.get_ownership_verification_record(custom_domain)
-        spf_record = self.get_expected_spf_record(custom_domain)
-        for record in txt_records:
-            if record != verification_record and record != spf_record:
-                final_records.append(record)
-
-        return final_records
+            return DomainValidationResult(success=False, errors=txt_records)
 
     def __clean_spf_records(
         self, txt_records: List[str], custom_domain: CustomDomain

--- a/app/custom_domain_validation.py
+++ b/app/custom_domain_validation.py
@@ -11,6 +11,7 @@ from app.dns_utils import (
     get_network_dns_client,
 )
 from app.models import CustomDomain
+from app.utils import random_string
 
 
 @dataclass
@@ -42,6 +43,11 @@ class CustomDomainValidation:
             and domain.partner_id in self._partner_domain_validation_prefixes
         ):
             prefix = self._partner_domain_validation_prefixes[domain.partner_id]
+
+        if not domain.ownership_txt_token:
+            domain.ownership_txt_token = random_string(30)
+            Session.commit()
+
         return f"{prefix}-verification={domain.ownership_txt_token}"
 
     def get_expected_mx_records(self, domain: CustomDomain) -> list[MxRecord]:

--- a/app/dashboard/views/custom_domain.py
+++ b/app/dashboard/views/custom_domain.py
@@ -21,7 +21,9 @@ class NewCustomDomainForm(FlaskForm):
 @parallel_limiter.lock(only_when=lambda: request.method == "POST")
 def custom_domain():
     custom_domains = CustomDomain.filter_by(
-        user_id=current_user.id, is_sl_subdomain=False
+        user_id=current_user.id,
+        is_sl_subdomain=False,
+        pending_deletion=False,
     ).all()
     new_custom_domain_form = NewCustomDomainForm()
 

--- a/app/dns_utils.py
+++ b/app/dns_utils.py
@@ -106,7 +106,7 @@ class NetworkDNSClient(DNSClient):
 
     def get_txt_record(self, hostname: str) -> List[str]:
         try:
-            answers = self._resolver.resolve(hostname, "TXT", search=True)
+            answers = self._resolver.resolve(hostname, "TXT", search=False)
             ret = []
             for a in answers:  # type: dns.rdtypes.ANY.TXT.TXT
                 for record in a.strings:

--- a/tests/test_custom_domain_validation.py
+++ b/tests/test_custom_domain_validation.py
@@ -543,26 +543,3 @@ def test_custom_domain_validation_validate_dmarc_records_success():
 
     db_domain = CustomDomain.get_by(id=domain.id)
     assert db_domain.dmarc_verified is True
-
-
-def test_custom_domain_validation_validate_dmarc_cleans_verification_and_spf_records():
-    dns_client = InMemoryDNSClient()
-    validator = CustomDomainValidation(random_domain(), dns_client)
-
-    domain = create_custom_domain(random_domain())
-
-    wrong_record = random_string()
-    dns_client.set_txt_record(
-        hostname=f"_dmarc.{domain.domain}",
-        txt_list=[
-            wrong_record,
-            validator.get_expected_spf_record(domain),
-            validator.get_ownership_verification_record(domain),
-        ],
-    )
-
-    res = validator.validate_dmarc_records(domain)
-
-    assert res.success is False
-    assert len(res.errors) == 1
-    assert res.errors[0] == wrong_record

--- a/tests/test_custom_domain_validation.py
+++ b/tests/test_custom_domain_validation.py
@@ -470,6 +470,33 @@ def test_custom_domain_validation_validate_spf_records_partner_domain_success():
     assert db_domain.spf_verified is True
 
 
+def test_custom_domain_validation_validate_spf_cleans_verification_record():
+    dns_client = InMemoryDNSClient()
+    proton_partner_id = get_proton_partner().id
+
+    expected_domain = random_domain()
+    validator = CustomDomainValidation(
+        dkim_domain=random_domain(),
+        dns_client=dns_client,
+        partner_domains={proton_partner_id: expected_domain},
+    )
+
+    domain = create_custom_domain(random_domain())
+    domain.partner_id = proton_partner_id
+    Session.commit()
+
+    wrong_record = random_string()
+    dns_client.set_txt_record(
+        hostname=domain.domain,
+        txt_list=[wrong_record, validator.get_ownership_verification_record(domain)],
+    )
+    res = validator.validate_spf_records(domain)
+
+    assert res.success is False
+    assert len(res.errors) == 1
+    assert res.errors[0] == wrong_record
+
+
 # validate_dmarc_records
 def test_custom_domain_validation_validate_dmarc_records_empty_failure():
     dns_client = InMemoryDNSClient()
@@ -516,3 +543,26 @@ def test_custom_domain_validation_validate_dmarc_records_success():
 
     db_domain = CustomDomain.get_by(id=domain.id)
     assert db_domain.dmarc_verified is True
+
+
+def test_custom_domain_validation_validate_dmarc_cleans_verification_and_spf_records():
+    dns_client = InMemoryDNSClient()
+    validator = CustomDomainValidation(random_domain(), dns_client)
+
+    domain = create_custom_domain(random_domain())
+
+    wrong_record = random_string()
+    dns_client.set_txt_record(
+        hostname=f"_dmarc.{domain.domain}",
+        txt_list=[
+            wrong_record,
+            validator.get_expected_spf_record(domain),
+            validator.get_ownership_verification_record(domain),
+        ],
+    )
+
+    res = validator.validate_dmarc_records(domain)
+
+    assert res.success is False
+    assert len(res.errors) == 1
+    assert res.errors[0] == wrong_record


### PR DESCRIPTION
- clean unexpected records in SPF and DMARC validation
- Use `search=False` for TXT records
- Do not show custom domains pending deletion in dashboard