### PR TITLE
On alias transfer send the proper events

### DIFF
--- a/app/alias_utils.py
+++ b/app/alias_utils.py
@@ -30,6 +30,7 @@ from app.events.generated.event_pb2 import (
     AliasDeleted,
     AliasStatusChanged,
     EventContent,
+    AliasCreated,
 )
 from app.log import LOG
 from app.models import (
@@ -500,6 +501,28 @@ def transfer_alias(alias, new_user, new_mailboxes: [Mailbox]):
     # set some fields back to default
     alias.disable_pgp = False
     alias.pinned = False
+
+    EventDispatcher.send_event(
+        old_user,
+        EventContent(
+            alias_deleted=AliasDeleted(
+                id=alias.id,
+                email=alias.email,
+            )
+        ),
+    )
+    EventDispatcher.send_event(
+        new_user,
+        EventContent(
+            alias_created=AliasCreated(
+                id=alias.id,
+                email=alias.email,
+                note=alias.note,
+                enabled=alias.enabled,
+                created_at=int(alias.created_at.timestamp),
+            )
+        ),
+    )
 
     Session.commit()
 

--- a/tests/dashboard/test_alias_transfer.py
+++ b/tests/dashboard/test_alias_transfer.py
@@ -1,38 +1,72 @@
 import app.alias_utils
+from app import config
 from app.db import Session
+from app.events.event_dispatcher import GlobalDispatcher
 from app.models import (
     Alias,
     Mailbox,
-    User,
     AliasMailbox,
+)
+from tests.events.event_test_utils import (
+    OnMemoryDispatcher,
+    _get_event_from_string,
+    _create_linked_user,
 )
 from tests.utils import login
 
+on_memory_dispatcher = OnMemoryDispatcher()
+
+
+def setup_module():
+    GlobalDispatcher.set_dispatcher(on_memory_dispatcher)
+    config.EVENT_WEBHOOK = "http://test"
+
+
+def teardown_module():
+    GlobalDispatcher.set_dispatcher(None)
+    config.EVENT_WEBHOOK = None
+
 
 def test_alias_transfer(flask_client):
-    user = login(flask_client)
-    mb = Mailbox.create(user_id=user.id, email="mb@gmail.com", commit=True)
+    (source_user, source_user_pu) = _create_linked_user()
+    source_user = login(flask_client, source_user)
+    mb = Mailbox.create(user_id=source_user.id, email="mb@gmail.com", commit=True)
 
-    alias = Alias.create_new_random(user)
+    alias = Alias.create_new_random(source_user)
     Session.commit()
 
     AliasMailbox.create(alias_id=alias.id, mailbox_id=mb.id, commit=True)
 
-    new_user = User.create(
-        email="hey@example.com",
-        password="password",
-        activated=True,
-        commit=True,
-    )
+    (target_user, target_user_pu) = _create_linked_user()
 
     Mailbox.create(
-        user_id=new_user.id, email="hey2@example.com", verified=True, commit=True
+        user_id=target_user.id, email="hey2@example.com", verified=True, commit=True
     )
 
-    app.alias_utils.transfer_alias(alias, new_user, new_user.mailboxes())
+    on_memory_dispatcher.clear()
+    app.alias_utils.transfer_alias(alias, target_user, target_user.mailboxes())
 
     # refresh from db
     alias = Alias.get(alias.id)
-    assert alias.user == new_user
-    assert set(alias.mailboxes) == set(new_user.mailboxes())
+    assert alias.user == target_user
+    assert set(alias.mailboxes) == set(target_user.mailboxes())
     assert len(alias.mailboxes) == 2
+
+    # Check events
+    assert len(on_memory_dispatcher.memory) == 2
+    # 1st delete event
+    event_data = on_memory_dispatcher.memory[0]
+    event_content = _get_event_from_string(event_data, source_user, source_user_pu)
+    assert event_content.alias_deleted is not None
+    alias_deleted = event_content.alias_deleted
+    assert alias_deleted.id == alias.id
+    assert alias_deleted.email == alias.email
+    # 2nd create event
+    event_data = on_memory_dispatcher.memory[1]
+    event_content = _get_event_from_string(event_data, target_user, target_user_pu)
+    assert event_content.alias_created is not None
+    alias_created = event_content.alias_created
+    assert alias.id == alias_created.id
+    assert alias.email == alias_created.email
+    assert alias.note or "" == alias_created.note
+    assert alias.enabled == alias_created.enabled

--- a/tests/events/event_test_utils.py
+++ b/tests/events/event_test_utils.py
@@ -1,4 +1,5 @@
 from app.events.event_dispatcher import Dispatcher
+from app.events.generated import event_pb2
 from app.models import PartnerUser, User
 from app.proton.utils import get_proton_partner
 from tests.utils import create_new_user, random_token
@@ -30,3 +31,14 @@ def _create_linked_user() -> Tuple[User, PartnerUser]:
     )
 
     return user, partner_user
+
+
+def _get_event_from_string(
+    data: str, user: User, pu: PartnerUser
+) -> event_pb2.EventContent:
+    event = event_pb2.Event()
+    event.ParseFromString(data)
+    assert user.id == event.user_id
+    assert pu.external_user_id == event.external_user_id
+    assert pu.partner_id == event.partner_id
+    return event.content

--- a/tests/events/test_sent_events.py
+++ b/tests/events/test_sent_events.py
@@ -1,12 +1,12 @@
 from app import config, alias_utils
 from app.db import Session
 from app.events.event_dispatcher import GlobalDispatcher
-from app.events.generated import event_pb2
-from app.models import Alias, User, PartnerUser
+from app.models import Alias
 from tests.utils import random_token
 from .event_test_utils import (
     OnMemoryDispatcher,
     _create_linked_user,
+    _get_event_from_string,
 )
 
 on_memory_dispatcher = OnMemoryDispatcher()
@@ -24,17 +24,6 @@ def teardown_module():
 
 def setup_function(func):
     on_memory_dispatcher.clear()
-
-
-def _get_event_from_string(
-    data: str, user: User, pu: PartnerUser
-) -> event_pb2.EventContent:
-    event = event_pb2.Event()
-    event.ParseFromString(data)
-    assert user.id == event.user_id
-    assert pu.external_user_id == event.external_user_id
-    assert pu.partner_id == event.partner_id
-    return event.content
 
 
 def test_fire_event_on_alias_creation():


### PR DESCRIPTION
When transferring an alias send events for:
 - delete alias for source user
 - create alias for target user
