### PR TITLE
Allow several job runners to run in parallel

### DIFF
--- a/tests/jobs/test_job_runner.py
+++ b/tests/jobs/test_job_runner.py
@@ -66,7 +66,8 @@ def test_get_jobs_to_run(flask_client):
         ),
     )
     Session.commit()
-    jobs = get_jobs_to_run()
+    taken_before_time = arrow.now().shift(minutes=-config.JOB_TAKEN_RETRY_WAIT_MINS)
+    jobs = get_jobs_to_run(taken_before_time)
     assert len(jobs) == len(expected_jobs_to_run)
     job_ids = [job.id for job in jobs]
     for job in expected_jobs_to_run:


### PR DESCRIPTION
By ensuring we only take a job transactionally we can have several job runners running in parallel to scale them up.