### PR TITLE
add arm64 builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,7 +163,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
 


### PR DESCRIPTION
This PR adds arm64 builds back in. 

I forked the repo and tested it against my own and appeared to run as expected.