### PR TITLE
chore: add missing indices for user and mailbox

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -565,6 +565,7 @@ class User(Base, ModelMixin, UserMixin, PasswordOracle):
             "ix_users_activated_trial_end_lifetime", activated, trial_end, lifetime
         ),
         sa.Index("ix_users_delete_on", delete_on),
+        sa.Index("ix_users_default_mailbox_id", default_mailbox_id),
     )
 
     @property
@@ -2752,7 +2753,10 @@ class Mailbox(Base, ModelMixin):
 
     generic_subject = sa.Column(sa.String(78), nullable=True)
 
-    __table_args__ = (sa.UniqueConstraint("user_id", "email", name="uq_mailbox_user"),)
+    __table_args__ = (
+        sa.UniqueConstraint("user_id", "email", name="uq_mailbox_user"),
+        sa.Index("ix_mailbox_pgp_finger_print", "pgp_finger_print"),
+    )
 
     user = orm.relationship(User, foreign_keys=[user_id])
 

--- a/migrations/versions/2024_111315_842ac670096e_add_missing_indices_on_user_and_mailbox.py
+++ b/migrations/versions/2024_111315_842ac670096e_add_missing_indices_on_user_and_mailbox.py
@@ -1,0 +1,30 @@
+"""add missing indices on user and mailbox
+
+Revision ID: 842ac670096e
+Revises: bc9aa210efa3
+Create Date: 2024-11-13 15:55:28.798506
+
+"""
+import sqlalchemy_utils
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '842ac670096e'
+down_revision = 'bc9aa210efa3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.create_index('ix_mailbox_pgp_finger_print', 'mailbox', ['pgp_finger_print'], unique=False)
+        op.create_index('ix_users_default_mailbox_id', 'users', ['default_mailbox_id'], unique=False)
+    # ### end Alembic commands ###
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.drop_index('ix_users_default_mailbox_id', table_name='users')
+        op.drop_index('ix_mailbox_pgp_finger_print', table_name='mailbox')


### PR DESCRIPTION
This PR adds two missing indices:

- `users.default_mailbox_id`. This one was really important, as when deleting a mailbox it would cause a full-table scan for `users` in order to try to find a user with the `mailbox_id` that was going to be deleted.
- `mailbox.pgp_finger_print`