### PR TITLE
Allow to use header from if domain is aligned with envelope

### DIFF
--- a/app/mailbox_utils.py
+++ b/app/mailbox_utils.py
@@ -12,11 +12,13 @@ from app.email_utils import (
     email_can_be_used_as_mailbox,
     send_email,
     render,
+    get_email_domain_part,
 )
 from app.email_validation import is_valid_email
 from app.log import LOG
-from app.models import User, Mailbox, Job, MailboxActivation
+from app.models import User, Mailbox, Job, MailboxActivation, Alias
 from app.user_audit_log_utils import emit_user_audit_log, UserAuditLogAction
+from app.utils import canonicalize_email
 
 
 @dataclasses.dataclass
@@ -328,3 +330,56 @@ def perform_mailbox_email_change(mailbox_id: int) -> MailboxEmailChangeResult:
             message="Invalid link",
             message_category="error",
         )
+
+
+def __get_alias_mailbox_from_email(
+    email_address: str, alias: Alias
+) -> Optional[Mailbox]:
+    for mailbox in alias.mailboxes:
+        if mailbox.email == email_address:
+            return mailbox
+
+        for authorized_address in mailbox.authorized_addresses:
+            if authorized_address.email == email_address:
+                LOG.d(
+                    "Found an authorized address for %s %s %s",
+                    alias,
+                    mailbox,
+                    authorized_address,
+                )
+                return mailbox
+    return None
+
+
+def __get_alias_mailbox_from_email_or_canonical_email(
+    email_address: str, alias: Alias
+) -> Optional[Mailbox]:
+    # We need to first check for the uncanonicalized version because we still have users in the db with the
+    # email non canonicalized. So if it matches the already existing one use that, otherwise check the canonical one
+    mbox = __get_alias_mailbox_from_email(email_address, alias)
+    if mbox is not None:
+        return mbox
+    canonical_email = canonicalize_email(email_address)
+    if canonical_email != email_address:
+        return __get_alias_mailbox_from_email(canonical_email, alias)
+    return None
+
+
+def get_mailbox_for_reply_phase(
+    envelope_mail_from: str, header_mail_from: str, alias
+) -> Optional[Mailbox]:
+    """return the corresponding mailbox given the mail_from and alias
+    Usually the mail_from=mailbox.email but it can also be one of the authorized address
+    """
+    mbox = __get_alias_mailbox_from_email_or_canonical_email(envelope_mail_from, alias)
+    if mbox is not None:
+        return mbox
+    if not header_mail_from:
+        return None
+    envelope_from_domain = get_email_domain_part(envelope_mail_from)
+    header_from_domain = get_email_domain_part(header_mail_from)
+    if envelope_from_domain != header_from_domain:
+        return None
+    # For services that use VERP sending (envelope from has encoded data to account for bounces)
+    # if the domain is the same in the header from as the envelope from we can use the header from
+    return __get_alias_mailbox_from_email_or_canonical_email(header_mail_from, alias)

--- a/tests/test_email_handler.py
+++ b/tests/test_email_handler.py
@@ -14,94 +14,19 @@ from app.email_utils import generate_verp_email
 from app.mail_sender import mail_sender
 from app.models import (
     Alias,
-    AuthorizedAddress,
     IgnoredEmail,
     EmailLog,
     Notification,
     VerpType,
     Contact,
     SentAlert,
-    Mailbox,
 )
 from app.utils import random_string, canonicalize_email
 from email_handler import (
-    get_mailbox_from_mail_from,
     should_ignore,
     is_automatic_out_of_office,
 )
 from tests.utils import load_eml_file, create_new_user, random_email
-
-
-def test_get_mailbox_from_mail_from(flask_client):
-    user = create_new_user()
-    alias = Alias.create_new_random(user)
-    Session.commit()
-
-    mb = get_mailbox_from_mail_from(user.email, "", alias)
-    assert mb.email == user.email
-
-    mb = get_mailbox_from_mail_from("unauthorized@gmail.com", "", alias)
-    assert mb is None
-
-    # authorized address
-    AuthorizedAddress.create(
-        user_id=user.id,
-        mailbox_id=user.default_mailbox_id,
-        email="unauthorized@gmail.com",
-        commit=True,
-    )
-    mb = get_mailbox_from_mail_from("unauthorized@gmail.com", "", alias)
-    assert mb.email == user.email
-
-
-def test_get_mailbox_from_mail_from_for_canonical_email(flask_client):
-    prefix = random_string(10)
-    email = f"{prefix}+subaddresxs@gmail.com"
-    canonical_email = canonicalize_email(email)
-    assert canonical_email != email
-
-    user = create_new_user()
-    mbox = Mailbox.create(
-        email=canonical_email, user_id=user.id, verified=True, flush=True
-    )
-    alias = Alias.create(user_id=user.id, email=random_email(), mailbox_id=mbox.id)
-    Session.flush()
-
-    mb = get_mailbox_from_mail_from(email, "", alias)
-    assert mb.email == canonical_email
-
-    mb = get_mailbox_from_mail_from(canonical_email, "", alias)
-    assert mb.email == canonical_email
-
-
-def test_get_mailbox_from_mail_from_coming_from_header_if_domain_is_aligned(
-    flask_client,
-):
-    domain = f"{random_string(10)}.com"
-    envelope_from = f"envelope_verp@{domain}"
-    mail_from = f"mail_from@{domain}"
-    user = create_new_user()
-    mbox = Mailbox.create(email=mail_from, user_id=user.id, verified=True, flush=True)
-    alias = Alias.create(user_id=user.id, email=random_email(), mailbox_id=mbox.id)
-    Session.flush()
-
-    mb = get_mailbox_from_mail_from(envelope_from, mail_from, alias)
-    assert mb.email == mail_from
-
-
-def test_get_mailbox_from_mail_from_coming_from_header_if_domain_is_not_aligned(
-    flask_client,
-):
-    domain = f"{random_string(10)}.com"
-    envelope_from = f"envelope_verp@{domain}"
-    mail_from = f"mail_from@other_{domain}"
-    user = create_new_user()
-    mbox = Mailbox.create(email=mail_from, user_id=user.id, verified=True, flush=True)
-    alias = Alias.create(user_id=user.id, email=random_email(), mailbox_id=mbox.id)
-    Session.flush()
-
-    mb = get_mailbox_from_mail_from(envelope_from, mail_from, alias)
-    assert mb is None
 
 
 def test_should_ignore(flask_client):


### PR DESCRIPTION
Use the mail_from when receiving a mail to the reverse alias if the domain is aligned with the VERP email