### PR TITLE
Add sudo to Docker commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ If you already have a Postgres database in use, you can skip this section and ju
 Run a Postgres Docker container as your Postgres database server. Make sure to replace `myuser` and `mypassword` with something more secret.
 
 ```bash
-docker run -d \
+sudo docker run -d \
     --name sl-db \
     -e POSTGRES_PASSWORD=mypassword \
     -e POSTGRES_USER=myuser \
@@ -246,7 +246,7 @@ docker run -d \
 To test whether the database operates correctly or not, run the following command:
 
 ```bash
-docker exec -it sl-db psql -U myuser simplelogin
+sudo docker exec -it sl-db psql -U myuser simplelogin
 ```
 
 you should be logged in the postgres console. Type `exit` to exit postgres console.
@@ -422,7 +422,7 @@ POSTFIX_SERVER=10.0.0.1
 Before running the webapp, you need to prepare the database by running the migration:
 
 ```bash
-docker run --rm \
+sudo docker run --rm \
     --name sl-migration \
     -v $(pwd)/sl:/sl \
     -v $(pwd)/sl/upload:/code/static/upload \
@@ -438,7 +438,7 @@ This command could take a while to download the `simplelogin/app` docker image.
 Init data
 
 ```bash
-docker run --rm \
+sudo docker run --rm \
     --name sl-init \
     -v $(pwd)/sl:/sl \
     -v $(pwd)/simplelogin.env:/code/.env \
@@ -451,7 +451,7 @@ docker run --rm \
 Now, it's time to run the `webapp` container!
 
 ```bash
-docker run -d \
+sudo docker run -d \
     --name sl-app \
     -v $(pwd)/sl:/sl \
     -v $(pwd)/sl/upload:/code/static/upload \
@@ -467,7 +467,7 @@ docker run -d \
 Next run the `email handler`
 
 ```bash
-docker run -d \
+sudo docker run -d \
     --name sl-email \
     -v $(pwd)/sl:/sl \
     -v $(pwd)/sl/upload:/code/static/upload \
@@ -483,7 +483,7 @@ docker run -d \
 And finally the `job runner`
 
 ```bash
-docker run -d \
+sudo docker run -d \
     --name sl-job-runner \
     -v $(pwd)/sl:/sl \
     -v $(pwd)/sl/upload:/code/static/upload \
@@ -534,7 +534,7 @@ By default, new accounts are not premium so don't have unlimited alias. To make 
 please go to the database, table "users" and set "lifetime" column to "1" or "TRUE":
 
 ```
-docker exec -it sl-db psql -U myuser simplelogin
+sudo docker exec -it sl-db psql -U myuser simplelogin
 UPDATE users SET lifetime = TRUE;
 exit
 ```
@@ -546,7 +546,7 @@ DISABLE_REGISTRATION=1
 DISABLE_ONBOARDING=true
 ```
 
-Then restart the web app to apply: `docker restart sl-app`
+Then restart the web app to apply: `sudo docker restart sl-app`
 
 ### Donations Welcome
 


### PR DESCRIPTION
Ensure the commands work for all users, including those who haven’t configured Docker for non-sudo access.