### PR TITLE
Two fixes

### DIFF
--- a/app/admin_model.py
+++ b/app/admin_model.py
@@ -791,7 +791,7 @@ class EmailSearchResult:
         self.query: str
 
     @staticmethod
-    def from_email(email: str) -> EmailSearchResult:
+    def from_request_email(email: str) -> EmailSearchResult:
         output = EmailSearchResult()
         output.query = email
         alias = Alias.get_by(email=email)
@@ -803,7 +803,11 @@ class EmailSearchResult:
                 .all()
             )
             output.no_match = False
-        user = User.get_by(email=email)
+        try:
+            user_id = int(email)
+            user = User.get(user_id)
+        except ValueError:
+            user = User.get_by(email=email)
         if user:
             output.user = user
             output.user_audit_log = (
@@ -912,7 +916,7 @@ class EmailSearchAdmin(BaseView):
         email = request.args.get("email")
         if email is not None and len(email) > 0:
             email = email.strip()
-            search = EmailSearchResult.from_email(email)
+            search = EmailSearchResult.from_request_email(email)
 
         return self.render(
             "admin/email_search.html",

--- a/app/models.py
+++ b/app/models.py
@@ -343,7 +343,7 @@ class Fido(Base, ModelMixin):
 class User(Base, ModelMixin, UserMixin, PasswordOracle):
     __tablename__ = "users"
 
-    FLAG_DISABLE_CREATE_CONTACTS = 1 << 0
+    FLAG_FREE_DISABLE_CREATE_CONTACTS = 1 << 0
     FLAG_CREATED_FROM_PARTNER = 1 << 1
     FLAG_FREE_OLD_ALIAS_LIMIT = 1 << 2
     FLAG_CREATED_ALIAS_FROM_PARTNER = 1 << 3
@@ -550,7 +550,7 @@ class User(Base, ModelMixin, UserMixin, PasswordOracle):
     # bitwise flags. Allow for future expansion
     flags = sa.Column(
         sa.BigInteger,
-        default=FLAG_DISABLE_CREATE_CONTACTS,
+        default=FLAG_FREE_DISABLE_CREATE_CONTACTS,
         server_default="0",
         nullable=False,
     )
@@ -640,7 +640,7 @@ class User(Base, ModelMixin, UserMixin, PasswordOracle):
         # If the user is created from partner, do not notify
         # nor give a trial
         if from_partner:
-            user.flags = User.FLAG_CREATED_FROM_PARTNER
+            user.flags = user.flags | User.FLAG_CREATED_FROM_PARTNER
             user.notification = False
             user.trial_end = None
             Job.create(
@@ -1189,7 +1189,7 @@ class User(Base, ModelMixin, UserMixin, PasswordOracle):
     def can_create_contacts(self) -> bool:
         if self.is_premium():
             return True
-        if self.flags & User.FLAG_DISABLE_CREATE_CONTACTS == 0:
+        if self.flags & User.FLAG_FREE_DISABLE_CREATE_CONTACTS == 0:
             return True
         return not config.DISABLE_CREATE_CONTACTS_FOR_FREE_USERS
 

--- a/email_handler.py
+++ b/email_handler.py
@@ -600,6 +600,17 @@ def handle_forward(envelope, msg: Message, rcpt_to: str) -> List[Tuple[bool, str
         else:
             reply_to_contact = get_or_create_reply_to_contact(reply_to, alias, msg)
 
+    if alias.user.delete_on is not None:
+        LOG.d(f"user {user} is pending to be deleted. Do not forward")
+        EmailLog.create(
+            contact_id=contact.id,
+            user_id=contact.user_id,
+            blocked=True,
+            alias_id=contact.alias_id,
+            commit=True,
+        )
+        return [(True, status.E502)]
+
     if not alias.enabled or contact.block_forward:
         LOG.d("%s is disabled, do not forward", alias)
         EmailLog.create(

--- a/tests/api/test_alias.py
+++ b/tests/api/test_alias.py
@@ -549,7 +549,7 @@ def test_create_contact_route_free_users(flask_client):
     assert r.status_code == 201
 
     # End trial and disallow for new free users. Config should allow it
-    user.flags = User.FLAG_DISABLE_CREATE_CONTACTS
+    user.flags = User.FLAG_FREE_DISABLE_CREATE_CONTACTS
     Session.commit()
     r = flask_client.post(
         url_for("api.create_contact_route", alias_id=alias.id),

--- a/tests/test_contact_utils.py
+++ b/tests/test_contact_utils.py
@@ -135,7 +135,7 @@ def test_create_contact_free_user():
     assert result.contact is not None
     assert not result.contact.automatic_created
     # Free users with the flag should be able to still create automatic emails
-    user.flags = User.FLAG_DISABLE_CREATE_CONTACTS
+    user.flags = User.FLAG_FREE_DISABLE_CREATE_CONTACTS
     Session.flush()
     result = create_contact(random_email(), alias, automatic_created=True)
     assert result.error is None

--- a/tests/test_email_handler.py
+++ b/tests/test_email_handler.py
@@ -2,6 +2,7 @@ import random
 from email.message import EmailMessage
 from typing import List
 
+import arrow
 import pytest
 from aiosmtpd.smtp import Envelope
 
@@ -387,3 +388,15 @@ def test_preserve_headers(flask_client):
     msg = sent_mails[0].msg
     for header in headers_to_keep:
         assert msg[header] == header + "keep"
+
+
+def test_not_send_to_pending_to_delete_users(flask_client):
+    user = create_new_user()
+    alias = Alias.create_new_random(user)
+    user.delete_on = arrow.utcnow()
+    envelope = Envelope()
+    envelope.mail_from = "somewhere@lo.cal"
+    envelope.rcpt_tos = [alias.email]
+    msg = EmailMessage()
+    result = email_handler.handle(envelope, msg)
+    assert result == status.E200

--- a/tests/test_email_handler.py
+++ b/tests/test_email_handler.py
@@ -399,4 +399,4 @@ def test_not_send_to_pending_to_delete_users(flask_client):
     envelope.rcpt_tos = [alias.email]
     msg = EmailMessage()
     result = email_handler.handle(envelope, msg)
-    assert result == status.E200
+    assert result == status.E504


### PR DESCRIPTION
- Preserve the user flag if user is being created from partner api
- Do not deliver email if user is pending deletion