### PR TITLE
feat: add request_id in log

### DIFF
--- a/app/log.py
+++ b/app/log.py
@@ -10,7 +10,7 @@ from app.config import (
 
 # this format allows clickable link to code source in PyCharm
 _log_format = (
-    "%(asctime)s - %(name)s - %(levelname)s - %(process)d - "
+    "%(asctime)s - %(name)s - %(levelname)s - %(process)d - %(request_id)s"
     '"%(pathname)s:%(lineno)d" - %(funcName)s() - %(message_id)s - %(message)s'
 )
 _log_formatter = logging.Formatter(_log_format)
@@ -37,6 +37,21 @@ class EmailHandlerFilter(logging.Filter):
         return _MESSAGE_ID
 
 
+class RequestIdFilter(logging.Filter):
+    """automatically add request-id to keep track of a request"""
+
+    def filter(self, record):
+        from flask import g, has_request_context
+
+        request_id = ""
+        if has_request_context():
+            ctx_request_id = getattr(g, "request_id")
+            if ctx_request_id:
+                request_id = f"{ctx_request_id} - "
+        record.request_id = request_id
+        return True
+
+
 def _get_console_handler():
     console_handler = logging.StreamHandler(sys.stdout)
     console_handler.setFormatter(_log_formatter)
@@ -54,6 +69,7 @@ def _get_logger(name) -> logging.Logger:
     logger.addHandler(_get_console_handler())
 
     logger.addFilter(EmailHandlerFilter())
+    logger.addFilter(RequestIdFilter())
 
     # no propagation to avoid propagating to root logger
     logger.propagate = False

--- a/app/request_utils.py
+++ b/app/request_utils.py
@@ -1,5 +1,6 @@
-def generate_request_id() -> str:
-    from random import randbytes
-    from base64 import b64encode
+from random import randbytes
+from base64 import b64encode
 
+
+def generate_request_id() -> str:
     return b64encode(randbytes(6)).decode()

--- a/app/request_utils.py
+++ b/app/request_utils.py
@@ -1,0 +1,5 @@
+def generate_request_id() -> str:
+    from random import randbytes
+    from base64 import b64encode
+
+    return b64encode(randbytes(6)).decode()

--- a/server.py
+++ b/server.py
@@ -106,6 +106,7 @@ from app.payments.coinbase import setup_coinbase_commerce
 from app.payments.paddle import setup_paddle_callback
 from app.phone.base import phone_bp
 from app.redis_services import initialize_redis_services
+from app.request_utils import generate_request_id
 from app.sentry_utils import sentry_before_send
 
 if SENTRY_DSN:
@@ -263,6 +264,7 @@ def set_index_page(app):
             and not request.path.startswith("/_debug_toolbar")
         ):
             g.start_time = time.time()
+            g.request_id = generate_request_id()
 
             # to handle the referral url that has ?slref=code part
             ref_code = request.args.get("slref")


### PR DESCRIPTION
Log messages now include a request_id parameter across all the log messages of the same request in order to improve log searching

See the request_id after the PID
```
2025-01-28 14:53:09,827 - SL - DEBUG - 35908 - TaH0/qx5 - "/Users/carlos/code/simple-login/app/server.py:286" - after_request() -  - 127.0.0.1 GET /auth/login ImmutableMultiDict([]) 200, takes 0.07936620712280273
```