### PR TITLE
fix: remove duplicate EmailLog index

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2124,9 +2124,7 @@ class EmailLog(Base, ModelMixin):
         Index("ix_email_log_user_id_email_log_id", "user_id", "id"),
     )
 
-    user_id = sa.Column(
-        sa.ForeignKey(User.id, ondelete="cascade"), nullable=False, index=True
-    )
+    user_id = sa.Column(sa.ForeignKey(User.id, ondelete="cascade"), nullable=False)
     contact_id = sa.Column(
         sa.ForeignKey(Contact.id, ondelete="cascade"), nullable=False, index=True
     )

--- a/migrations/versions/2025_013114_97edba8794f8_index_cleanup.py
+++ b/migrations/versions/2025_013114_97edba8794f8_index_cleanup.py
@@ -1,0 +1,23 @@
+"""index cleanup
+
+Revision ID: 97edba8794f8
+Revises: d3ff8848c930
+Create Date: 2025-01-31 14:42:22.590597
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '97edba8794f8'
+down_revision = 'd3ff8848c930'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_index('ix_email_log_user_id', table_name='email_log')
+
+
+def downgrade():
+    op.create_index('ix_email_log_user_id', 'email_log', ['user_id'], unique=False)


### PR DESCRIPTION
According to PGHero, this index is already covered by the `ix_email_log_user_id_email_log_id`

<img width="567" alt="image" src="https://github.com/user-attachments/assets/cc2f0c64-3889-4f76-869b-b72482b08686" />
