### PR TITLE
feat: job runner priorities

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -275,6 +275,12 @@ class AliasDeleteReason(EnumE):
     CustomDomainDeleted = 5
 
 
+class JobPriority(EnumE):
+    Low = 1
+    Default = 50
+    High = 100
+
+
 class IntEnumType(sa.types.TypeDecorator):
     impl = sa.Integer
 
@@ -2772,8 +2778,17 @@ class Job(Base, ModelMixin):
     )
     attempts = sa.Column(sa.Integer, nullable=False, server_default="0", default=0)
     taken_at = sa.Column(ArrowType, nullable=True)
+    priority = sa.Column(
+        IntEnumType(JobPriority),
+        default=JobPriority.Default,
+        server_default=str(JobPriority.Default.value),
+        nullable=False,
+    )
 
-    __table_args__ = (Index("ix_state_run_at_taken_at", state, run_at, taken_at),)
+    __table_args__ = (
+        Index("ix_state_run_at_taken_at", state, run_at, taken_at),
+        Index("ix_state_run_at_taken_at_priority", state, run_at, taken_at, priority),
+    )
 
     def __repr__(self):
         return f"<Job {self.id} {self.name} {self.payload}>"

--- a/job_runner.py
+++ b/job_runner.py
@@ -333,7 +333,7 @@ def get_jobs_to_run(taken_before_time: arrow.Arrow) -> List[Job]:
             or_(Job.run_at.is_(None), and_(Job.run_at <= run_at_earliest)),
         )
     )
-    return query.all()
+    return query.order_by(Job.priority.desc()).order_by(Job.run_at.asc()).all()
 
 
 def take_job(job: Job, taken_before_time: arrow.Arrow) -> bool:

--- a/migrations/versions/2025_022515_fd79503179dd_job_priorities.py
+++ b/migrations/versions/2025_022515_fd79503179dd_job_priorities.py
@@ -1,0 +1,29 @@
+"""job priorities
+
+Revision ID: fd79503179dd
+Revises: 20e7d3ca289a
+Create Date: 2025-02-25 15:39:24.833973
+
+"""
+import sqlalchemy_utils
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'fd79503179dd'
+down_revision = '20e7d3ca289a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.add_column('job', sa.Column('priority', sa.Integer(), server_default='50', nullable=False))
+        op.create_index('ix_state_run_at_taken_at_priority', 'job', ['state', 'run_at', 'taken_at', 'priority'], unique=False, postgresql_concurrently=True)
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.drop_index('ix_state_run_at_taken_at_priority', table_name='job',  postgresql_concurrently=True)
+        op.drop_column('job', 'priority')

--- a/tests/jobs/test_job_runner.py
+++ b/tests/jobs/test_job_runner.py
@@ -1,7 +1,7 @@
 from app import config
 from app.db import Session
 from job_runner import get_jobs_to_run
-from app.models import Job, JobState
+from app.models import Job, JobPriority, JobState
 import arrow
 
 
@@ -72,3 +72,42 @@ def test_get_jobs_to_run(flask_client):
     job_ids = [job.id for job in jobs]
     for job in expected_jobs_to_run:
         assert job.id in job_ids
+
+
+def test_get_jobs_to_run_respects_priority(flask_client):
+    now = arrow.now()
+    for job in Job.all():
+        Job.delete(job.id)
+
+    j1 = Job.create(
+        name="", payload="", run_at=now.shift(minutes=-1), priority=JobPriority.High
+    )
+    j2 = Job.create(
+        name="", payload="", run_at=now.shift(minutes=-2), priority=JobPriority.Default
+    )
+    j3 = Job.create(
+        name="", payload="", run_at=now.shift(minutes=-3), priority=JobPriority.Default
+    )
+    j4 = Job.create(
+        name="", payload="", run_at=now.shift(minutes=-4), priority=JobPriority.Low
+    )
+    j5 = Job.create(
+        name="", payload="", run_at=now.shift(minutes=-2), priority=JobPriority.High
+    )
+
+    Session.commit()
+    taken_before_time = arrow.now().shift(minutes=-config.JOB_TAKEN_RETRY_WAIT_MINS)
+    jobs = get_jobs_to_run(taken_before_time)
+    assert len(jobs) == 5
+
+    job_ids = [job.id for job in jobs]
+
+    # The expected outcome is:
+    # 1. j5 -> 2 mins ago and High
+    # 2. j1 -> 1 min ago and High
+    # --- The 2 above are high, so they should be the first ones. j5 is first as it's been pending for a longer time
+    # 3. j3 -> 3 mins ago and Default
+    # 4. j2 -> 2 mins ago and Default
+    # --- The 2 above are both default, and again, are sorted by run_at ascendingly
+    # 5. j4 -> 3 mins ago and Low. Even if it is the one that has been waiting the most, as it's Low, it's the last one
+    assert job_ids == [j5.id, j1.id, j3.id, j2.id, j4.id]


### PR DESCRIPTION
This PR adds the ability to define priorities for the Job instances that we create. It also modifies the `job_runner:: get_jobs_to_run` function so it sorts the jobs by priority (desc) and `run_at` (asc), so the execution respects priorities and waiting time.