### PR TITLE
refactor: move job names to enum in constants

### DIFF
--- a/app/api/views/user.py
+++ b/app/api/views/user.py
@@ -2,7 +2,7 @@ from flask import jsonify, g
 from sqlalchemy_utils.types.arrow import arrow
 
 from app.api.base import api_bp, require_api_sudo, require_api_auth
-from app import config
+from app.constants import JobType
 from app.extensions import limiter
 from app.log import LOG
 from app.models import Job, ApiToCookieToken
@@ -24,7 +24,7 @@ def delete_user():
     )
     LOG.w("schedule delete account job for %s", g.user)
     Job.create(
-        name=config.JOB_DELETE_ACCOUNT,
+        name=JobType.DELETE_ACCOUNT.value,
         payload={"user_id": g.user.id},
         run_at=arrow.now(),
         commit=True,

--- a/app/config.py
+++ b/app/config.py
@@ -316,20 +316,6 @@ MFA_USER_ID = "mfa_user_id"
 FLASK_PROFILER_PATH = os.environ.get("FLASK_PROFILER_PATH")
 FLASK_PROFILER_PASSWORD = os.environ.get("FLASK_PROFILER_PASSWORD")
 
-# Job names
-JOB_ONBOARDING_1 = "onboarding-1"
-JOB_ONBOARDING_2 = "onboarding-2"
-JOB_ONBOARDING_3 = "onboarding-3"
-JOB_ONBOARDING_4 = "onboarding-4"
-JOB_BATCH_IMPORT = "batch-import"
-JOB_DELETE_ACCOUNT = "delete-account"
-JOB_DELETE_MAILBOX = "delete-mailbox"
-JOB_DELETE_DOMAIN = "delete-domain"
-JOB_SEND_USER_REPORT = "send-user-report"
-JOB_SEND_PROTON_WELCOME_1 = "proton-welcome-1"
-JOB_SEND_ALIAS_CREATION_EVENTS = "send-alias-creation-events"
-JOB_SEND_EVENT_TO_WEBHOOK = "send-event-to-webhook"
-
 # for pagination
 PAGE_LIMIT = 20
 

--- a/app/constants.py
+++ b/app/constants.py
@@ -1,2 +1,18 @@
+import enum
+
 HEADER_ALLOW_API_COOKIES = "X-Sl-Allowcookies"
 DMARC_RECORD = "v=DMARC1; p=quarantine; pct=100; adkim=s; aspf=s"
+
+
+class JobType(enum.Enum):
+    ONBOARDING_1 = "onboarding-1"
+    ONBOARDING_2 = "onboarding-2"
+    ONBOARDING_4 = "onboarding-4"
+    BATCH_IMPORT = "batch-import"
+    DELETE_ACCOUNT = "delete-account"
+    DELETE_MAILBOX = "delete-mailbox"
+    DELETE_DOMAIN = "delete-domain"
+    SEND_USER_REPORT = "send-user-report"
+    SEND_PROTON_WELCOME_1 = "proton-welcome-1"
+    SEND_ALIAS_CREATION_EVENTS = "send-alias-creation-events"
+    SEND_EVENT_TO_WEBHOOK = "send-event-to-webhook"

--- a/app/custom_domain_utils.py
+++ b/app/custom_domain_utils.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional
 
-from app.config import JOB_DELETE_DOMAIN
+from app.constants import JobType
 from app.db import Session
 from app.email_utils import get_email_domain_part
 from app.log import LOG
@@ -156,7 +156,7 @@ def delete_custom_domain(domain: CustomDomain):
     LOG.w("schedule delete domain job for %s", domain)
     domain.pending_deletion = True
     Job.create(
-        name=JOB_DELETE_DOMAIN,
+        name=JobType.DELETE_DOMAIN.value,
         payload={"custom_domain_id": domain.id},
         run_at=arrow.now(),
         commit=True,

--- a/app/dashboard/views/batch_import.py
+++ b/app/dashboard/views/batch_import.py
@@ -3,7 +3,7 @@ from flask import render_template, flash, request, redirect, url_for
 from flask_login import login_required, current_user
 
 from app import s3
-from app.config import JOB_BATCH_IMPORT
+from app.constants import JobType
 from app.dashboard.base import dashboard_bp
 from app.dashboard.views.enter_sudo import sudo_required
 from app.db import Session
@@ -64,7 +64,7 @@ def batch_import_route():
 
         # Schedule batch import job
         Job.create(
-            name=JOB_BATCH_IMPORT,
+            name=JobType.BATCH_IMPORT.value,
             payload={"batch_import_id": bi.id},
             run_at=arrow.now(),
         )

--- a/app/dashboard/views/delete_account.py
+++ b/app/dashboard/views/delete_account.py
@@ -3,7 +3,7 @@ from flask import flash, redirect, url_for, request, render_template
 from flask_login import login_required, current_user
 from flask_wtf import FlaskForm
 
-from app.config import JOB_DELETE_ACCOUNT
+from app.constants import JobType
 from app.dashboard.base import dashboard_bp
 from app.dashboard.views.enter_sudo import sudo_required
 from app.log import LOG
@@ -40,7 +40,7 @@ def delete_account():
             message=f"User {current_user.id} ({current_user.email}) marked for deletion via webapp",
         )
         Job.create(
-            name=JOB_DELETE_ACCOUNT,
+            name=JobType.DELETE_ACCOUNT.value,
             payload={"user_id": current_user.id},
             run_at=arrow.now(),
             commit=True,

--- a/app/jobs/export_user_data_job.py
+++ b/app/jobs/export_user_data_job.py
@@ -12,6 +12,7 @@ import arrow
 import sqlalchemy
 
 from app import config
+from app.constants import JobType
 from app.db import Session
 from app.email import headers
 from app.email_utils import (
@@ -174,7 +175,7 @@ class ExportUserDataJob:
         jobs_in_db = (
             Session.query(Job)
             .filter(
-                Job.name == config.JOB_SEND_USER_REPORT,
+                Job.name == JobType.SEND_USER_REPORT.value,
                 Job.payload.op("->")("user_id").cast(sqlalchemy.TEXT)
                 == str(self._user.id),
                 Job.taken.is_(False),
@@ -184,7 +185,7 @@ class ExportUserDataJob:
         if jobs_in_db > 0:
             return None
         return Job.create(
-            name=config.JOB_SEND_USER_REPORT,
+            name=JobType.SEND_USER_REPORT.value,
             payload={"user_id": self._user.id},
             run_at=arrow.now(),
             commit=True,

--- a/app/jobs/send_event_job.py
+++ b/app/jobs/send_event_job.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 import arrow
 
-from app import config
+from app.constants import JobType
 from app.errors import ProtonPartnerNotSetUp
 from app.events.generated import event_pb2
 from app.events.generated.event_pb2 import EventContent
@@ -60,7 +60,7 @@ class SendEventToWebhookJob:
     def store_job_in_db(self, run_at: Optional[arrow.Arrow]) -> Job:
         stub = self._event.SerializeToString()
         return Job.create(
-            name=config.JOB_SEND_EVENT_TO_WEBHOOK,
+            name=JobType.SEND_EVENT_TO_WEBHOOK.value,
             payload={
                 "user_id": self._user.id,
                 "event": base64.b64encode(stub).decode("utf-8"),

--- a/app/mailbox_utils.py
+++ b/app/mailbox_utils.py
@@ -7,7 +7,7 @@ import arrow
 from sqlalchemy.exc import IntegrityError
 
 from app import config
-from app.config import JOB_DELETE_MAILBOX
+from app.constants import JobType
 from app.db import Session
 from app.email_utils import (
     mailbox_already_used,
@@ -156,7 +156,7 @@ def delete_mailbox(
         f"User {user} has scheduled delete mailbox job for {mailbox.id} with transfer to mailbox {transfer_mailbox_id}"
     )
     Job.create(
-        name=JOB_DELETE_MAILBOX,
+        name=JobType.DELETE_MAILBOX.value,
         payload={
             "mailbox_id": mailbox.id,
             "transfer_mailbox_id": transfer_mailbox_id

--- a/app/models.py
+++ b/app/models.py
@@ -30,6 +30,7 @@ from sqlalchemy_utils import ArrowType
 
 from app import config, rate_limiter
 from app import s3
+from app.constants import JobType
 from app.db import Session
 from app.dns_utils import get_mx_domains
 from app.errors import (
@@ -656,7 +657,7 @@ class User(Base, ModelMixin, UserMixin, PasswordOracle):
             user.notification = False
             user.trial_end = None
             Job.create(
-                name=config.JOB_SEND_PROTON_WELCOME_1,
+                name=JobType.SEND_PROTON_WELCOME_1.value,
                 payload={"user_id": user.id},
                 run_at=arrow.now(),
             )
@@ -682,17 +683,17 @@ class User(Base, ModelMixin, UserMixin, PasswordOracle):
 
         # Schedule onboarding emails
         Job.create(
-            name=config.JOB_ONBOARDING_1,
+            name=JobType.ONBOARDING_1.value,
             payload={"user_id": user.id},
             run_at=arrow.now().shift(days=1),
         )
         Job.create(
-            name=config.JOB_ONBOARDING_2,
+            name=JobType.ONBOARDING_2.value,
             payload={"user_id": user.id},
             run_at=arrow.now().shift(days=2),
         )
         Job.create(
-            name=config.JOB_ONBOARDING_4,
+            name=JobType.ONBOARDING_4.value,
             payload={"user_id": user.id},
             run_at=arrow.now().shift(days=3),
         )

--- a/app/partner_user_utils.py
+++ b/app/partner_user_utils.py
@@ -3,7 +3,7 @@ from typing import Optional
 import arrow
 from arrow import Arrow
 
-from app import config
+from app.constants import JobType
 from app.models import PartnerUser, PartnerSubscription, User, Job
 from app.user_audit_log_utils import emit_user_audit_log, UserAuditLogAction
 
@@ -18,7 +18,7 @@ def create_partner_user(
         external_user_id=external_user_id,
     )
     Job.create(
-        name=config.JOB_SEND_ALIAS_CREATION_EVENTS,
+        name=JobType.SEND_ALIAS_CREATION_EVENTS.value,
         payload={"user_id": user.id},
         run_at=arrow.now(),
     )

--- a/job_runner.py
+++ b/job_runner.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm.exc import ObjectDeletedError
 from sqlalchemy.sql.expression import or_, and_
 
 from app import config
+from app.constants import JobType
 from app.db import Session
 from app.email_utils import (
     send_email,
@@ -196,7 +197,7 @@ SimpleLogin team.
 
 def process_job(job: Job):
     send_version_event("job_runner")
-    if job.name == config.JOB_ONBOARDING_1:
+    if job.name == JobType.ONBOARDING_1.value:
         user_id = job.payload.get("user_id")
         user = User.get(user_id)
 
@@ -205,7 +206,7 @@ def process_job(job: Job):
         if user and user.notification and user.activated:
             LOG.d("send onboarding send-from-alias email to user %s", user)
             onboarding_send_from_alias(user)
-    elif job.name == config.JOB_ONBOARDING_2:
+    elif job.name == JobType.ONBOARDING_2.value:
         user_id = job.payload.get("user_id")
         user = User.get(user_id)
 
@@ -214,7 +215,7 @@ def process_job(job: Job):
         if user and user.notification and user.activated:
             LOG.d("send onboarding mailbox email to user %s", user)
             onboarding_mailbox(user)
-    elif job.name == config.JOB_ONBOARDING_4:
+    elif job.name == JobType.ONBOARDING_4.value:
         user_id = job.payload.get("user_id")
         user: User = User.get(user_id)
 
@@ -229,11 +230,11 @@ def process_job(job: Job):
                 LOG.d("send onboarding pgp email to user %s", user)
                 onboarding_pgp(user)
 
-    elif job.name == config.JOB_BATCH_IMPORT:
+    elif job.name == JobType.BATCH_IMPORT.value:
         batch_import_id = job.payload.get("batch_import_id")
         batch_import = BatchImport.get(batch_import_id)
         handle_batch_import(batch_import)
-    elif job.name == config.JOB_DELETE_ACCOUNT:
+    elif job.name == JobType.DELETE_ACCOUNT.value:
         user_id = job.payload.get("user_id")
         user = User.get(user_id)
 
@@ -252,10 +253,10 @@ def process_job(job: Job):
         )
         User.delete(user.id)
         Session.commit()
-    elif job.name == config.JOB_DELETE_MAILBOX:
+    elif job.name == JobType.DELETE_MAILBOX.value:
         delete_mailbox_job(job)
 
-    elif job.name == config.JOB_DELETE_DOMAIN:
+    elif job.name == JobType.DELETE_DOMAIN.value:
         custom_domain_id = job.payload.get("custom_domain_id")
         custom_domain: Optional[CustomDomain] = CustomDomain.get(custom_domain_id)
         if not custom_domain:
@@ -292,17 +293,17 @@ def process_job(job: Job):
     """,
                 retries=3,
             )
-    elif job.name == config.JOB_SEND_USER_REPORT:
+    elif job.name == JobType.SEND_USER_REPORT.value:
         export_job = ExportUserDataJob.create_from_job(job)
         if export_job:
             export_job.run()
-    elif job.name == config.JOB_SEND_PROTON_WELCOME_1:
+    elif job.name == JobType.SEND_PROTON_WELCOME_1.value:
         user_id = job.payload.get("user_id")
         user = User.get(user_id)
         if user and user.activated:
             LOG.d("Send proton welcome email to user %s", user)
             welcome_proton(user)
-    elif job.name == config.JOB_SEND_ALIAS_CREATION_EVENTS:
+    elif job.name == JobType.SEND_ALIAS_CREATION_EVENTS.value:
         user_id = job.payload.get("user_id")
         user = User.get(user_id)
         if user and user.activated:
@@ -310,7 +311,7 @@ def process_job(job: Job):
             send_alias_creation_events_for_user(
                 user, dispatcher=PostgresDispatcher.get()
             )
-    elif job.name == config.JOB_SEND_EVENT_TO_WEBHOOK:
+    elif job.name == JobType.SEND_EVENT_TO_WEBHOOK.value:
         send_job = SendEventToWebhookJob.create_from_job(job)
         if send_job:
             send_job.run(HttpEventSink())

--- a/tests/api/test_user.py
+++ b/tests/api/test_user.py
@@ -2,7 +2,7 @@ from random import random
 
 from flask import url_for
 
-from app import config
+from app.constants import JobType
 from app.db import Session
 from app.models import Job, ApiToCookieToken
 from tests.api.utils import get_new_user_and_api_key
@@ -48,7 +48,7 @@ def test_delete_with_sudo(flask_client):
     jobs = Job.all()
     assert len(jobs) == 1
     job = jobs[0]
-    assert job.name == config.JOB_DELETE_ACCOUNT
+    assert job.name == JobType.DELETE_ACCOUNT.value
     assert job.payload == {"user_id": user.id}
 
 

--- a/tests/jobs/test_delete_mailbox_job.py
+++ b/tests/jobs/test_delete_mailbox_job.py
@@ -1,6 +1,6 @@
 from sqlalchemy_utils.types.arrow import arrow
 
-from app.config import JOB_DELETE_MAILBOX
+from app.constants import JobType
 from app.db import Session
 from app.mail_sender import mail_sender
 from app.models import Alias, Mailbox, Job, AliasMailbox
@@ -21,7 +21,7 @@ def test_delete_mailbox_transfer_mailbox_primary(flask_client):
     alias_id = Alias.create_new(user, "prefix", mailbox_id=m1.id).id
     AliasMailbox.create(alias_id=alias_id, mailbox_id=m2.id)
     job = Job.create(
-        name=JOB_DELETE_MAILBOX,
+        name=JobType.DELETE_MAILBOX.value,
         payload={"mailbox_id": m1.id, "transfer_mailbox_id": m2.id},
         run_at=arrow.now(),
         commit=True,
@@ -43,7 +43,7 @@ def test_delete_mailbox_no_email(flask_client):
         user_id=user.id, email=random_email(), verified=True, flush=True
     )
     job = Job.create(
-        name=JOB_DELETE_MAILBOX,
+        name=JobType.DELETE_MAILBOX.value,
         payload={"mailbox_id": m1.id, "transfer_mailbox_id": None, "send_mail": False},
         run_at=arrow.now(),
         commit=True,
@@ -70,7 +70,7 @@ def test_delete_mailbox_transfer_mailbox_in_list(flask_client):
     alias_id = Alias.create_new(user, "prefix", mailbox_id=m1.id).id
     AliasMailbox.create(alias_id=alias_id, mailbox_id=m2.id)
     job = Job.create(
-        name=JOB_DELETE_MAILBOX,
+        name=JobType.DELETE_MAILBOX.value,
         payload={"mailbox_id": m2.id, "transfer_mailbox_id": m3.id},
         run_at=arrow.now(),
         commit=True,
@@ -95,7 +95,7 @@ def test_delete_mailbox_no_transfer(flask_client):
 
     alias_id = Alias.create_new(user, "prefix", mailbox_id=m1.id).id
     job = Job.create(
-        name=JOB_DELETE_MAILBOX,
+        name=JobType.DELETE_MAILBOX.value,
         payload={"mailbox_id": m1.id},
         run_at=arrow.now(),
         commit=True,

--- a/tests/jobs/test_send_event_to_webhook.py
+++ b/tests/jobs/test_send_event_to_webhook.py
@@ -1,6 +1,6 @@
 import arrow
 
-from app import config
+from app.constants import JobType
 from app.events.generated.event_pb2 import EventContent, AliasDeleted
 from app.jobs.send_event_job import SendEventToWebhookJob
 from app.models import PartnerUser
@@ -17,7 +17,7 @@ def test_serialize_and_deserialize_job():
     run_at = arrow.now().shift(hours=10)
     db_job = SendEventToWebhookJob(user, event).store_job_in_db(run_at=run_at)
     assert db_job.run_at == run_at
-    assert db_job.name == config.JOB_SEND_EVENT_TO_WEBHOOK
+    assert db_job.name == JobType.SEND_EVENT_TO_WEBHOOK.value
     job = SendEventToWebhookJob.create_from_job(db_job)
     assert job._user.id == user.id
     assert job._event.alias_deleted.id == alias_id

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -1,5 +1,6 @@
 import arrow
-from app import config
+
+from app.constants import JobType
 from app.db import Session
 from app.models import User, Job, PartnerSubscription, PartnerUser, ManualSubscription
 from app.proton.proton_partner import get_proton_partner
@@ -16,7 +17,7 @@ def test_create_from_partner(flask_client):
     assert user.newsletter_alias_id is None
     job = Session.query(Job).order_by(Job.id.desc()).first()
     assert job is not None
-    assert job.name == config.JOB_SEND_PROTON_WELCOME_1
+    assert job.name == JobType.SEND_PROTON_WELCOME_1.value
     assert job.payload.get("user_id") == user.id
 
 

--- a/tests/proton/test_proton_callback_handler.py
+++ b/tests/proton/test_proton_callback_handler.py
@@ -1,10 +1,10 @@
 from arrow import Arrow
 
-from app import config
 from app.account_linking import (
     SLPlan,
     SLPlanType,
 )
+from app.constants import JobType
 from app.proton.proton_client import ProtonClient, UserInformation
 from app.proton.proton_callback_handler import (
     ProtonCallbackHandler,
@@ -28,7 +28,7 @@ class MockProtonClient(ProtonClient):
 def check_initial_sync_job(user: User, expected: bool):
     found = False
     for job in Job.yield_per_query(10).filter_by(
-        name=config.JOB_SEND_ALIAS_CREATION_EVENTS,
+        name=JobType.SEND_ALIAS_CREATION_EVENTS.value,
         state=JobState.ready.value,
     ):
         if job.payload.get("user_id") == user.id:

--- a/tests/test_mailbox_utils.py
+++ b/tests/test_mailbox_utils.py
@@ -5,6 +5,7 @@ import arrow
 import pytest
 
 from app import mailbox_utils, config
+from app.constants import JobType
 from app.db import Session
 from app.mail_sender import mail_sender
 from app.mailbox_utils import (
@@ -231,7 +232,7 @@ def test_delete_with_no_transfer():
     mailbox_utils.delete_mailbox(user, mailbox.id, transfer_mailbox_id=None)
     job = Session.query(Job).order_by(Job.id.desc()).first()
     assert job is not None
-    assert job.name == config.JOB_DELETE_MAILBOX
+    assert job.name == JobType.DELETE_MAILBOX.value
     assert job.payload["mailbox_id"] == mailbox.id
     assert job.payload["transfer_mailbox_id"] is None
 
@@ -252,13 +253,13 @@ def test_delete_with_transfer():
     )
     job = Session.query(Job).order_by(Job.id.desc()).first()
     assert job is not None
-    assert job.name == config.JOB_DELETE_MAILBOX
+    assert job.name == JobType.DELETE_MAILBOX.value
     assert job.payload["mailbox_id"] == mailbox.id
     assert job.payload["transfer_mailbox_id"] == transfer_mailbox.id
     mailbox_utils.delete_mailbox(user, mailbox.id, transfer_mailbox_id=None)
     job = Session.query(Job).order_by(Job.id.desc()).first()
     assert job is not None
-    assert job.name == config.JOB_DELETE_MAILBOX
+    assert job.name == JobType.DELETE_MAILBOX.value
     assert job.payload["mailbox_id"] == mailbox.id
     assert job.payload["transfer_mailbox_id"] is None
 


### PR DESCRIPTION
This PR moves the job names out of the `config` module into a `JobType` enum in `constants`, as they are not configurable and so we trim down a bit the `config.py` file