### PR TITLE
Preserve Unsubscribe header and create one that always unsubs via alias

### DIFF
--- a/app/email/headers.py
+++ b/app/email/headers.py
@@ -38,6 +38,8 @@ SL_ENVELOPE_FROM = "X-SimpleLogin-Envelope-From"
 SL_ORIGINAL_FROM = "X-SimpleLogin-Original-From"
 SL_ENVELOPE_TO = "X-SimpleLogin-Envelope-To"
 SL_CLIENT_IP = "X-SimpleLogin-Client-IP"
+SL_ORIGINAL_LIST_UNSUBSCRIBE = "X-SimpleLogin-Original-List-Unsubscribe"
+SL_ORIGINAL_LIST_UNSUBSCRIBE_POST = "X-SimpleLogin-Original-List-Unsubscribe-Post"
 
 # to let Rspamd know that the message should be signed
 SL_WANT_SIGNING = "X-SimpleLogin-Want-Signing"

--- a/app/handler/unsubscribe_generator.py
+++ b/app/handler/unsubscribe_generator.py
@@ -16,9 +16,9 @@ from app.models import Alias, Contact, UnsubscribeBehaviourEnum
 
 
 class UnsubscribeGenerator:
-    def _generate_header_with_original_behaviour(
+    def _calculate_header_with_original_behaviour(
         self, alias: Alias, message: Message
-    ) -> Message:
+    ) -> dict[str, str]:
         """
         Generate a header that will encode the original unsub request. To do so
          1. Look if there's an original List_Unsubscribe headers, otherwise do nothing
@@ -34,7 +34,7 @@ class UnsubscribeGenerator:
         unsubscribe_data = message[headers.LIST_UNSUBSCRIBE]
         if not unsubscribe_data:
             LOG.info("Email has no unsubscribe header")
-            return message
+            return {}
         if isinstance(unsubscribe_data, Header):
             unsubscribe_data = str(unsubscribe_data.encode())
         raw_methods = [method.strip() for method in unsubscribe_data.split(",")]
@@ -56,7 +56,12 @@ class UnsubscribeGenerator:
                     LOG.debug(
                         f"Skipping replacing unsubscribe since the original email already points to {config.UNSUBSCRIBER}"
                     )
-                    return message
+                    out = {headers.LIST_UNSUBSCRIBE: unsubscribe_data}
+                    if message[headers.LIST_UNSUBSCRIBE_POST]:
+                        out[headers.LIST_UNSUBSCRIBE_POST] = str(
+                            message[headers.LIST_UNSUBSCRIBE_POST]
+                        )
+                    return out
                 query_data = urllib.parse.parse_qs(url_data.query)
                 mailto_unsubs = (url_data.path, query_data.get("subject", [""])[0])
                 LOG.debug(f"Unsub is mailto to {mailto_unsubs}")
@@ -65,27 +70,34 @@ class UnsubscribeGenerator:
                 other_unsubs.append(method)
         # If there are non mailto unsubscribe methods, use those in the header
         if other_unsubs:
-            add_or_replace_header(
-                message,
-                headers.LIST_UNSUBSCRIBE,
-                ", ".join([f"<{method}>" for method in other_unsubs]),
-            )
-            add_or_replace_header(
-                message, headers.LIST_UNSUBSCRIBE_POST, "List-Unsubscribe=One-Click"
-            )
             LOG.debug(f"Adding click unsub methods to header {other_unsubs}")
-            return message
+            return {
+                headers.LIST_UNSUBSCRIBE: ", ".join(
+                    [f"<{method}>" for method in other_unsubs]
+                ),
+                headers.LIST_UNSUBSCRIBE_POST: "List-Unsubscribe=One-Click",
+            }
         elif not mailto_unsubs:
             LOG.debug("No unsubs. Deleting all unsub headers")
-            delete_header(message, headers.LIST_UNSUBSCRIBE)
-            delete_header(message, headers.LIST_UNSUBSCRIBE_POST)
-            return message
-        unsub_data = UnsubscribeData(
+            return {}
+        unsub_link = UnsubscribeEncoder.encode(
             UnsubscribeAction.OriginalUnsubscribeMailto,
             UnsubscribeOriginalData(alias.id, mailto_unsubs[0], mailto_unsubs[1]),
         )
-        LOG.debug(f"Adding unsub data {unsub_data}")
-        return self._add_unsubscribe_header(message, unsub_data)
+        LOG.debug(f"Adding unsub link {unsub_link.link}")
+        out = {headers.LIST_UNSUBSCRIBE: f"<{unsub_link.link}>"}
+        if not unsub_link.via_email:
+            out[headers.LIST_UNSUBSCRIBE_POST] = "List-Unsubscribe=One-Click"
+        return out
+
+    def __replace_unsub_headers(
+        self, message, unsub_headers: dict[str, str]
+    ) -> Message:
+        delete_header(message, headers.LIST_UNSUBSCRIBE)
+        delete_header(message, headers.LIST_UNSUBSCRIBE_POST)
+        for header in unsub_headers:
+            add_or_replace_header(message, header, unsub_headers[header])
+        return message
 
     def _add_unsubscribe_header(
         self, message: Message, unsub: UnsubscribeData
@@ -106,9 +118,12 @@ class UnsubscribeGenerator:
         Add List-Unsubscribe header based on the user preference.
         """
         unsub_behaviour = alias.user.unsub_behaviour
-        message = self.__preserve_original_headers(message)
+        original_unsub_proxied = self._calculate_header_with_original_behaviour(
+            alias, message
+        )
+        message = self.__preserve_original_headers(message, original_unsub_proxied)
         if unsub_behaviour == UnsubscribeBehaviourEnum.PreserveOriginal:
-            return self._generate_header_with_original_behaviour(alias, message)
+            return self.__replace_unsub_headers(message, original_unsub_proxied)
         elif unsub_behaviour == UnsubscribeBehaviourEnum.DisableAlias:
             unsub = UnsubscribeData(UnsubscribeAction.DisableAlias, alias.id)
             return self._add_unsubscribe_header(message, unsub)
@@ -116,7 +131,9 @@ class UnsubscribeGenerator:
             unsub = UnsubscribeData(UnsubscribeAction.DisableContact, contact.id)
             return self._add_unsubscribe_header(message, unsub)
 
-    def __preserve_original_headers(self, message: Message) -> Message:
+    def __preserve_original_headers(
+        self, message: Message, original_unsub_proxied: dict[str, str]
+    ) -> Message:
         unsubscribe_data = message[headers.LIST_UNSUBSCRIBE]
         if unsubscribe_data:
             add_or_replace_header(
@@ -127,4 +144,9 @@ class UnsubscribeGenerator:
             add_or_replace_header(
                 message, headers.SL_ORIGINAL_LIST_UNSUBSCRIBE_POST, unsubscribe_data
             )
+        for header in original_unsub_proxied:
+            add_or_replace_header(
+                message, f"X-SL-Proxy-{header}", original_unsub_proxied[header]
+            )
+
         return message

--- a/app/handler/unsubscribe_generator.py
+++ b/app/handler/unsubscribe_generator.py
@@ -106,6 +106,7 @@ class UnsubscribeGenerator:
         Add List-Unsubscribe header based on the user preference.
         """
         unsub_behaviour = alias.user.unsub_behaviour
+        message = self.__preserve_original_headers(message)
         if unsub_behaviour == UnsubscribeBehaviourEnum.PreserveOriginal:
             return self._generate_header_with_original_behaviour(alias, message)
         elif unsub_behaviour == UnsubscribeBehaviourEnum.DisableAlias:
@@ -114,3 +115,16 @@ class UnsubscribeGenerator:
         else:
             unsub = UnsubscribeData(UnsubscribeAction.DisableContact, contact.id)
             return self._add_unsubscribe_header(message, unsub)
+
+    def __preserve_original_headers(self, message: Message) -> Message:
+        unsubscribe_data = message[headers.LIST_UNSUBSCRIBE]
+        if unsubscribe_data:
+            add_or_replace_header(
+                message, headers.SL_ORIGINAL_LIST_UNSUBSCRIBE, unsubscribe_data
+            )
+        unsubscribe_data = message[headers.LIST_UNSUBSCRIBE_POST]
+        if unsubscribe_data:
+            add_or_replace_header(
+                message, headers.SL_ORIGINAL_LIST_UNSUBSCRIBE_POST, unsubscribe_data
+            )
+        return message

--- a/tests/handler/test_unsubscribe_generator.py
+++ b/tests/handler/test_unsubscribe_generator.py
@@ -205,6 +205,14 @@ def test_unsub_preserve_original(
         assert message[headers.LIST_UNSUBSCRIBE_POST] is None
     else:
         assert "List-Unsubscribe=One-Click" == message[headers.LIST_UNSUBSCRIBE_POST]
+        assert (
+            "List-Unsubscribe=One-Click"
+            == message[f"X-SL-Proxy-{headers.LIST_UNSUBSCRIBE_POST}"]
+        )
+    assert (
+        message[headers.LIST_UNSUBSCRIBE]
+        == message[f"X-SL-Proxy-{headers.LIST_UNSUBSCRIBE}"]
+    )
     assert message[headers.SL_ORIGINAL_LIST_UNSUBSCRIBE] == original_header
 
 

--- a/tests/handler/test_unsubscribe_generator.py
+++ b/tests/handler/test_unsubscribe_generator.py
@@ -75,6 +75,7 @@ def test_unsub_disable_contact(
         assert message[headers.LIST_UNSUBSCRIBE_POST] is None
     else:
         assert "List-Unsubscribe=One-Click" == message[headers.LIST_UNSUBSCRIBE_POST]
+    assert message[headers.SL_ORIGINAL_LIST_UNSUBSCRIBE] == original_header
 
 
 def generate_unsub_disable_alias_data() -> Iterable:
@@ -134,6 +135,7 @@ def test_unsub_disable_alias(
         assert message[headers.LIST_UNSUBSCRIBE_POST] is None
     else:
         assert "List-Unsubscribe=One-Click" == message[headers.LIST_UNSUBSCRIBE_POST]
+    assert message[headers.SL_ORIGINAL_LIST_UNSUBSCRIBE] == original_header
 
 
 def generate_unsub_preserve_original_data() -> Iterable:
@@ -203,6 +205,7 @@ def test_unsub_preserve_original(
         assert message[headers.LIST_UNSUBSCRIBE_POST] is None
     else:
         assert "List-Unsubscribe=One-Click" == message[headers.LIST_UNSUBSCRIBE_POST]
+    assert message[headers.SL_ORIGINAL_LIST_UNSUBSCRIBE] == original_header
 
 
 def test_unsub_preserves_sl_unsubscriber():
@@ -223,3 +226,45 @@ def test_unsub_preserves_sl_unsubscriber():
     message[headers.LIST_UNSUBSCRIBE] = original_header
     message = UnsubscribeGenerator().add_header_to_message(alias, contact, message)
     assert original_header == message[headers.LIST_UNSUBSCRIBE]
+    assert message[headers.SL_ORIGINAL_LIST_UNSUBSCRIBE] == original_header
+
+
+def test_unsub_preserves_nothing_if_there_is_no_original_unsub():
+    user = create_new_user()
+    user.unsub_behaviour = UnsubscribeBehaviourEnum.PreserveOriginal
+    alias = Alias.create_new_random(user)
+    Session.flush()
+    contact = Contact.create(
+        user_id=user.id,
+        alias_id=alias.id,
+        website_email="contact@example.com",
+        reply_email="rep@sl.lan",
+        commit=True,
+    )
+    message = Message()
+    message = UnsubscribeGenerator().add_header_to_message(alias, contact, message)
+    assert message[headers.SL_ORIGINAL_LIST_UNSUBSCRIBE] is None
+    assert message[headers.SL_ORIGINAL_LIST_UNSUBSCRIBE_POST] is None
+
+
+def test_unsub_preserves_original():
+    user = create_new_user()
+    user.unsub_behaviour = UnsubscribeBehaviourEnum.PreserveOriginal
+    alias = Alias.create_new_random(user)
+    Session.flush()
+    contact = Contact.create(
+        user_id=user.id,
+        alias_id=alias.id,
+        website_email="contact@example.com",
+        reply_email="rep@sl.lan",
+        commit=True,
+    )
+    message = Message()
+    original_header = f"<mailto:{config.UNSUBSCRIBER}?subject=dummysubject>"
+    message[headers.LIST_UNSUBSCRIBE] = original_header
+    message[headers.LIST_UNSUBSCRIBE_POST] = original_header + "post"
+    message = UnsubscribeGenerator().add_header_to_message(alias, contact, message)
+    assert message[headers.SL_ORIGINAL_LIST_UNSUBSCRIBE] == original_header
+    assert (
+        message[headers.SL_ORIGINAL_LIST_UNSUBSCRIBE_POST] == original_header + "post"
+    )


### PR DESCRIPTION
If there's an original `List-Unsubscribe` header:
 - Preserve original under `X-SL-Original-List-Unsubscribe`
 - Create a `X-SL-Proxy-List-Unsubscribe` that will send the original unsub request from the alias