### PR TITLE
IDTEAM-4740: use parallel_limiter to prevent auth_mfa abusing.

### DIFF
--- a/app/api/views/auth_mfa.py
+++ b/app/api/views/auth_mfa.py
@@ -8,11 +8,13 @@ from app.api.base import api_bp
 from app.config import FLASK_SECRET
 from app.db import Session
 from app.email_utils import send_invalid_totp_login_email
+from app.extensions import limiter
 from app.log import LOG
 from app.models import User, ApiKey
 
 
 @api_bp.route("/auth/mfa", methods=["POST"])
+@limiter.limit("10/minute")
 @parallel_limiter.lock(name="mfa_auth")
 def auth_mfa():
     """

--- a/app/api/views/auth_mfa.py
+++ b/app/api/views/auth_mfa.py
@@ -3,17 +3,17 @@ from flask import jsonify, request
 from flask_login import login_user
 from itsdangerous import Signer
 
+from app import parallel_limiter
 from app.api.base import api_bp
 from app.config import FLASK_SECRET
 from app.db import Session
 from app.email_utils import send_invalid_totp_login_email
-from app.extensions import limiter
 from app.log import LOG
 from app.models import User, ApiKey
 
 
 @api_bp.route("/auth/mfa", methods=["POST"])
-@limiter.limit("10/minute")
+@parallel_limiter.lock(name="mfa_auth")
 def auth_mfa():
     """
     Validate the OTP Token


### PR DESCRIPTION
This code change applies `parallel_limiter` to the MFA endpoint to prevent users from abusing it by sending multiple requests in parallel. 