### PR TITLE
fix: commit alias deletion on API + add filter on trashed aliases in api

### DIFF
--- a/app/api/serializer.py
+++ b/app/api/serializer.py
@@ -120,7 +120,7 @@ def get_alias_infos_with_pagination(user, page_id=0, query=None) -> [AliasInfo]:
     q = (
         Session.query(Alias)
         .options(joinedload(Alias.mailbox))
-        .filter(Alias.user_id == user.id)
+        .filter(Alias.user_id == user.id, Alias.delete_on == None)  # noqa: E711
         .order_by(Alias.created_at.desc())
     )
 

--- a/app/api/views/alias.py
+++ b/app/api/views/alias.py
@@ -165,7 +165,8 @@ def delete_alias(alias_id):
     if not alias or alias.user_id != user.id:
         return jsonify(error="Forbidden"), 403
 
-    alias_delete.delete_alias(alias, user, AliasDeleteReason.ManualAction)
+    LOG.i(f"User {user} is deleting alias {alias}")
+    alias_delete.delete_alias(alias, user, AliasDeleteReason.ManualAction, commit=True)
 
     return jsonify(deleted=True), 200
 


### PR DESCRIPTION
This PR performs the following changes:

1. Add a filter on trashed aliases on the deprecated API endpoint
2. Add a missing commit call when moving an alias to trash