### PR TITLE
chore: add logs on alias creation

### DIFF
--- a/app/alias_utils.py
+++ b/app/alias_utils.py
@@ -135,7 +135,7 @@ def check_if_alias_can_be_auto_created_for_custom_domain(
         else:  # no rule passes
             LOG.d(f"No rule matches auto-create {address} for domain {custom_domain}")
             return None
-    LOG.d("Create alias via catchall")
+    LOG.d(f"User {custom_domain.user} will create alias {address} via catchall")
 
     return custom_domain, None
 
@@ -253,6 +253,8 @@ def try_auto_create_directory(address: str) -> Optional[Alias]:
             )
 
         Session.commit()
+
+        LOG.i(f"User {directory.user} created alias {alias} via directory {directory}")
         return alias
     except AliasInTrashError:
         LOG.w(
@@ -301,6 +303,9 @@ def try_auto_create_via_domain(address: str) -> Optional[Alias]:
             custom_domain_id=custom_domain.id,
             automatic_creation=True,
             mailbox_id=mailboxes[0].id,
+        )
+        LOG.d(
+            f"User {custom_domain.user} created alias {alias} via domain {custom_domain}"
         )
         if not custom_domain.user.disable_automatic_alias_note:
             alias.note = alias_note

--- a/app/api/views/new_custom_alias.py
+++ b/app/api/views/new_custom_alias.py
@@ -120,6 +120,7 @@ def new_custom_alias_v2():
         return jsonify(error="Email is not valid"), 400
 
     Session.commit()
+    LOG.i(f"User {user} created custom alias {alias} via API (v2)")
 
     if hostname:
         AliasUsedOn.create(alias_id=alias.id, hostname=hostname, user_id=alias.user_id)
@@ -264,6 +265,8 @@ def new_custom_alias_v3():
         )
 
     Session.commit()
+
+    LOG.i(f"User {user} created custom alias {alias} via API (v3)")
 
     if hostname:
         AliasUsedOn.create(alias_id=alias.id, hostname=hostname, user_id=alias.user_id)

--- a/app/api/views/new_random_alias.py
+++ b/app/api/views/new_random_alias.py
@@ -88,6 +88,7 @@ def new_random_alias():
                     mailbox_id=user.default_mailbox_id,
                     commit=True,
                 )
+                LOG.i(f"User {user} created random alias {alias} via API")
             except AliasInTrashError:
                 LOG.i("Alias %s is in trash", suggested_alias)
                 alias = None
@@ -108,6 +109,7 @@ def new_random_alias():
 
         alias = Alias.create_new_random(user=user, scheme=scheme, note=note)
         Session.commit()
+        LOG.i(f"User {user} created random alias {alias} via API")
 
     if hostname and not AliasUsedOn.get_by(alias_id=alias.id, hostname=hostname):
         AliasUsedOn.create(

--- a/app/dashboard/views/custom_alias.py
+++ b/app/dashboard/views/custom_alias.py
@@ -156,6 +156,9 @@ def custom_alias():
                     )
 
                 Session.commit()
+                LOG.i(
+                    f"User {current_user} has created custom alias {alias} via dashboard"
+                )
                 flash(f"Alias {full_alias} has been created", "success")
 
                 return redirect(url_for("dashboard.index", highlight_alias_id=alias.id))


### PR DESCRIPTION
This PR adds some logs on alias creation, to help when debugging which route was used to create an alias