### PR TITLE
fix: mailbox deletion respects alias setting

### DIFF
--- a/tests/test_alias_delete.py
+++ b/tests/test_alias_delete.py
@@ -43,13 +43,17 @@ def teardown_module():
 
 def ensure_alias_is_trashed(
     alias: Alias, expected_audit_log_size: int, reason: AliasDeleteReason
-):
-    assert alias.enabled is False
-    assert alias.delete_on is not None
-    assert alias.delete_reason == reason
+) -> Alias:
+    db_alias = Alias.get(alias.id)
+    assert db_alias is not None
+    assert db_alias.enabled is False
+    assert db_alias.delete_on is not None
+    assert db_alias.delete_reason == reason
 
     # Ensure audit log
-    audit_logs: List[AliasAuditLog] = AliasAuditLog.filter_by(alias_id=alias.id).all()
+    audit_logs: List[AliasAuditLog] = AliasAuditLog.filter_by(
+        alias_id=db_alias.id
+    ).all()
     assert len(audit_logs) == expected_audit_log_size
     assert (
         audit_logs[expected_audit_log_size - 2].action
@@ -61,8 +65,10 @@ def ensure_alias_is_trashed(
     )
 
     # Ensure DeletedAlias instance is not created
-    deleted_alias: Optional[DeletedAlias] = DeletedAlias.get_by(email=alias.email)
+    deleted_alias: Optional[DeletedAlias] = DeletedAlias.get_by(email=db_alias.email)
     assert deleted_alias is None
+
+    return db_alias
 
 
 def ensure_alias_is_deleted(
@@ -205,9 +211,16 @@ def test_delete_mailbox_deletes_alias_with_user_setting(
 
     Mailbox.delete(mb.id)
 
-    ensure_alias_is_deleted(
-        alias_id, alias_email, 2, reason=AliasDeleteReason.MailboxDeleted
-    )
+    if user_setting == UserAliasDeleteAction.MoveToTrash:
+        db_alias = ensure_alias_is_trashed(
+            alias, 2, reason=AliasDeleteReason.MailboxDeleted
+        )
+        # Ensure mailbox_id has been changed to the user's default mailbox id
+        assert db_alias.mailbox_id == user.default_mailbox_id
+    elif user_setting == UserAliasDeleteAction.DeleteImmediately:
+        ensure_alias_is_deleted(
+            alias_id, alias_email, 2, reason=AliasDeleteReason.MailboxDeleted
+        )
 
 
 # Restore alias


### PR DESCRIPTION
When deleting a mailbox, if the user setting is set to send alias to the trash, this setting was not being taken into account