### PR TITLE
chore: add log when deleting alias

### DIFF
--- a/app/alias_delete.py
+++ b/app/alias_delete.py
@@ -23,6 +23,7 @@ def __delete_alias(alias: Alias, user: User, commit: bool):
     alias_id = alias.id
     alias_email = alias.email
 
+    LOG.info(f"Performing alias deletion for {alias} of user {user}")
     emit_alias_audit_log(
         alias, AliasAuditLogAction.DeleteAlias, "Alias deleted by user action"
     )


### PR DESCRIPTION
Add a log line when an alias is deleted. This is really helpful when debugging missing aliases that have been deleted after the alias was trashed.