### PR TITLE
Fix condition to avoid duplicate lines

### DIFF
--- a/app/api/serializer.py
+++ b/app/api/serializer.py
@@ -164,7 +164,11 @@ def get_alias_infos_with_pagination_v3(
 
     if mailbox_id:
         q = q.join(
-            AliasMailbox, Alias.id == AliasMailbox.alias_id, isouter=True
+            AliasMailbox,
+            and_(
+                Alias.id == AliasMailbox.alias_id, AliasMailbox.mailbox_id == mailbox_id
+            ),
+            isouter=True,
         ).filter(
             or_(Alias.mailbox_id == mailbox_id, AliasMailbox.mailbox_id == mailbox_id)
         )


### PR DESCRIPTION
By not having the and each alias that had an aliasmailbox with another mailbox appeared twice and it was deduped after making the limit count not work properly