### PR TITLE
improve debugging: save bounces to transactional mails to disk

### DIFF
--- a/email_handler.py
+++ b/email_handler.py
@@ -1872,9 +1872,7 @@ def handle_transactional_bounce(
 ):
     LOG.d("handle transactional bounce sent to %s", rcpt_to)
     if transactional_id is None:
-        LOG.i(
-            f"No transactional id for {envelope.mail_from} -> {envelope.rcpt_tos}"
-        )
+        LOG.i(f"No transactional id for {envelope.mail_from} -> {envelope.rcpt_tos}")
         save_envelope_for_debugging(envelope, "no-txid")
         return
 


### PR DESCRIPTION
When an internal transactional mail (i.e. validation of a new mailbox, or a new user) bounces, this bounce is completely discarded. To improve debugging (the cause of the bounce), this pull request enables saving the bounces content to TEMP_DIR.