### PR TITLE
Handle None case for default_factory in config:---->The error is caused because your sl_getenv function is being called without a proper default_factory.

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -30,7 +30,9 @@ def sl_getenv(env_var: str, default_factory: Callable = None):
     """
     value = os.getenv(env_var)
     if value is None:
-        return default_factory()
+        if default_factory is None:
+        return None
+    return default_factory()
 
     return literal_eval(value)
 


### PR DESCRIPTION
Return None if default_factory is None.