### PR TITLE
Follow CNAME records when resolving MX records

### DIFF
--- a/app/dns_utils.py
+++ b/app/dns_utils.py
@@ -88,7 +88,19 @@ class NetworkDNSClient(DNSClient):
                 prio = int(parts[0])
                 if prio not in ret:
                     ret[prio] = []
-                ret[prio].append(parts[1])
+                domain_name = parts[1]
+
+                # Follow CNAME records
+                while True:
+                    try:
+                        cname_answers = self._resolver.resolve(
+                            domain_name, "CNAME", search=True
+                        )
+                    except dns.resolver.NoAnswer:
+                        break
+                    domain_name = cname_answers[0].to_text()
+                ret[prio].append(domain_name)
+
         except Exception:
             pass
         return ret


### PR DESCRIPTION
Updated the MX domain name resolution logic, so that it follows any CNAME records through to the final MX server. This resolves an issue where a correct DNS setup still flags up a warning email saying it's incorrect.

Fixes #2575.

Tested on my own custom domain, which has these rules:

```
MX sl.domain.tld mx1.sl.domain.tld 10
MX sl.domain.tld mx2.sl.domain.tld 20
CNAME mx1.sl.domain.tld mx1.simplelogin.co
CNAME mx2.sl.domain.tld mx2.simplelogin.co
```

Before:

```cmd
> python -c "from app.email_utils import get_mx_domains; print(get_mx_domains('sl.domain.tld'))"
{10: ['mx1.sl.domain.tld.'], 20: ['mx2.sl.domain.tld.']}
```

After:

```cmd
> python -c "from app.email_utils import get_mx_domains; print(get_mx_domains('sl.domain.tld'))"
{10: ['mx1.simplelogin.co.'], 20: ['mx2.simplelogin.co.']}
```