### PR TITLE
Disallow custom domains to be used as mailbox domains

### DIFF
--- a/app/email_utils.py
+++ b/app/email_utils.py
@@ -595,8 +595,9 @@ def email_can_be_used_as_mailbox(email_address: str) -> bool:
 
     from app.models import CustomDomain
 
-    if CustomDomain.get_by(domain=domain, is_sl_subdomain=True, verified=True):
-        LOG.d("domain %s is a SimpleLogin custom domain", domain)
+    custom_domain = CustomDomain.get_by(domain=domain, verified=True)
+    if custom_domain is not None:
+        LOG.d("domain %s is custom domain %s", domain, custom_domain)
         return False
 
     if is_invalid_mailbox_domain(domain):

--- a/tests/test_email_utils.py
+++ b/tests/test_email_utils.py
@@ -89,7 +89,7 @@ def test_email_belongs_to_alias_domains():
     assert not can_create_directory_for_address("hey@d3.lan")
 
 
-def test_can_be_used_as_personal_email(flask_client):
+def test_cannot_be_used_as_personal_email(flask_client):
     dns_client.set_mx_records("sl.lan", {10: ["mxdomain.com."]})
     dns_client.set_mx_records("d1.lan", {10: ["mxdomain.com."]})
     dns_client.set_mx_records("protonmail.com", {10: ["mxdomain.com."]})
@@ -110,7 +110,7 @@ def test_can_be_used_as_personal_email(flask_client):
     # custom domain is NOT SL domain
     domain_obj.is_sl_subdomain = False
     Session.flush()
-    assert email_can_be_used_as_mailbox(f"hey@{domain}")
+    assert not email_can_be_used_as_mailbox(f"hey@{domain}")
 
     # disposable domain
     disposable_domain = random_domain()


### PR DESCRIPTION
If they have a custom domain to create alias, it should not be used as mailbox to avoid a loop.