### PR TITLE
deps: upgrade sl-pgp to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ ignore = "H006,H013,H016,H017,H019,H021,H025,H030,H031,T003,J004,J018,T001"
 
 [tool.uv]
 # Declare sl-pgp-rs dependency link so uv can find it
-find-links = ["https://github.com/simple-login/sl-pgp-rs/releases/download/0.1.0/index.html"]
+find-links = ["https://github.com/simple-login/sl-pgp-rs/releases/download/0.1.1/index.html"]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -1931,12 +1931,12 @@ wheels = [
 
 [[package]]
 name = "sl-pgp"
-version = "0.1.0"
-source = { registry = "https://github.com/simple-login/sl-pgp-rs/releases/download/0.1.0/index.html" }
+version = "0.1.1"
+source = { registry = "https://github.com/simple-login/sl-pgp-rs/releases/download/0.1.1/index.html" }
 wheels = [
-    { url = "https://github.com/simple-login/sl-pgp-rs/releases/download/0.1.0/sl_pgp-0.1.0-cp310-abi3-manylinux_2_31_aarch64.whl" },
-    { url = "https://github.com/simple-login/sl-pgp-rs/releases/download/0.1.0/sl_pgp-0.1.0-cp310-abi3-manylinux_2_31_x86_64.whl" },
-    { url = "https://github.com/simple-login/sl-pgp-rs/releases/download/0.1.0/sl_pgp-0.1.0-cp310-abi3-macosx_11_0_arm64.whl" },
+    { url = "https://github.com/simple-login/sl-pgp-rs/releases/download/0.1.1/sl_pgp-0.1.1-cp310-abi3-manylinux_2_31_aarch64.whl" },
+    { url = "https://github.com/simple-login/sl-pgp-rs/releases/download/0.1.1/sl_pgp-0.1.1-cp310-abi3-manylinux_2_31_x86_64.whl" },
+    { url = "https://github.com/simple-login/sl-pgp-rs/releases/download/0.1.1/sl_pgp-0.1.1-cp310-abi3-macosx_11_0_arm64.whl" },
 ]
 
 [[package]]


### PR DESCRIPTION
This change upgrades `sl-pgp` to `0.1.1` so all returned fingerprints are uppercase