### PR TITLE
Document up to date PostgreSQL docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,10 +237,10 @@ docker run -d \
     -e POSTGRES_USER=myuser \
     -e POSTGRES_DB=simplelogin \
     -p 127.0.0.1:5432:5432 \
-    -v $(pwd)/sl/db:/var/lib/postgresql/data \
+    -v $(pwd)/sl/db:/var/lib/postgresql \
     --restart always \
     --network="sl-network" \
-    postgres:12.1
+    postgres:18.1
 ```
 
 To test whether the database operates correctly or not, run the following command:

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -141,10 +141,10 @@ docker run -d \
     -e POSTGRES_USER=myuser \
     -e POSTGRES_DB=simplelogin \
     -p 127.0.0.1:5432:5432 \
-    -v $(pwd)/sl/db:/var/lib/postgresql/data \
+    -v $(pwd)/sl/db:/var/lib/postgresql \
     --restart always \
     --network="sl-network" \
-    postgres:12.1
+    postgres:18.1
 
 # Run the database migration
 sudo docker run --rm \


### PR DESCRIPTION
Fixes #2664 

PostgreSQL is supported in Docker with official images.
This PR sets the image for self-hosting to the lastest up-to-date `18.1` version.

Version `18+` will make it easy to upgrade across major versions in the future.
It now requires the database folder to be mounted slightly differently:

```patch
    -e POSTGRES_USER=myuser \
    -e POSTGRES_DB=simplelogin \
    -p 127.0.0.1:5432:5432 \
-   -v $(pwd)/sl/db:/var/lib/postgresql/data \
+   -v $(pwd)/sl/db:/var/lib/postgresql \
    --restart always \
    --network="sl-network" \
-   postgres:12.1
+   postgres:18.1
```