### PR TITLE
Add global sender blacklist (regex) with admin UI and SMTP blocking

### DIFF
--- a/app/admin/__init__.py
+++ b/app/admin/__init__.py
@@ -16,6 +16,7 @@ from app.admin.newsletter import NewsletterAdmin, NewsletterUserAdmin
 from app.admin.metrics import DailyMetricAdmin, MetricAdmin
 from app.admin.invalid_mailbox_domain import InvalidMailboxDomainAdmin
 from app.admin.forbidden_mx_ip import ForbiddenMxIpAdmin
+from app.admin.global_sender_blacklist import GlobalSenderBlacklistAdmin
 from app.admin.email_search import (
     EmailSearchResult,
     EmailSearchHelpers,
@@ -52,6 +53,7 @@ __all__ = [
     "MetricAdmin",
     "InvalidMailboxDomainAdmin",
     "ForbiddenMxIpAdmin",
+    "GlobalSenderBlacklistAdmin",
     # Search views
     "EmailSearchResult",
     "EmailSearchHelpers",

--- a/app/admin/global_sender_blacklist.py
+++ b/app/admin/global_sender_blacklist.py
@@ -1,0 +1,15 @@
+from flask_admin.form import SecureForm
+
+from app.admin.base import SLModelView
+
+
+class GlobalSenderBlacklistAdmin(SLModelView):
+    form_base_class = SecureForm
+
+    can_create = True
+    can_edit = True
+    can_delete = True
+
+    column_searchable_list = ("pattern", "comment")
+    column_filters = ("enabled",)
+    column_editable_list = ("enabled", "comment")

--- a/app/admin/index.py
+++ b/app/admin/index.py
@@ -17,6 +17,7 @@ from app.models import (
     Metric2,
     InvalidMailboxDomain,
     ForbiddenMxIp,
+    GlobalSenderBlacklist,
 )
 from app.admin.base import SLAdminIndexView
 from app.admin.user import UserAdmin
@@ -31,6 +32,7 @@ from app.admin.newsletter import NewsletterAdmin, NewsletterUserAdmin
 from app.admin.metrics import DailyMetricAdmin, MetricAdmin
 from app.admin.invalid_mailbox_domain import InvalidMailboxDomainAdmin
 from app.admin.forbidden_mx_ip import ForbiddenMxIpAdmin
+from app.admin.global_sender_blacklist import GlobalSenderBlacklistAdmin
 from app.admin.email_search import EmailSearchAdmin
 from app.admin.custom_domain_search import CustomDomainSearchAdmin
 from app.admin.abuser_lookup import AbuserLookupAdmin
@@ -63,3 +65,4 @@ def init_admin(app: Flask):
     admin.add_view(MetricAdmin(Metric2, Session))
     admin.add_view(InvalidMailboxDomainAdmin(InvalidMailboxDomain, Session))
     admin.add_view(ForbiddenMxIpAdmin(ForbiddenMxIp, Session))
+    admin.add_view(GlobalSenderBlacklistAdmin(GlobalSenderBlacklist, Session))

--- a/app/models.py
+++ b/app/models.py
@@ -3672,6 +3672,24 @@ class ForbiddenMxIp(Base, ModelMixin):
     comment = sa.Column(sa.Text, unique=False, nullable=True)
 
 
+class GlobalSenderBlacklist(Base, ModelMixin):
+    """Global blacklist for inbound senders (envelope MAIL FROM).
+
+    Pattern is a (re2-compatible) regex that is applied via search() against the
+    full envelope sender address.
+
+    Examples:
+      - "@spamdomain\\.com$"
+      - "^no-?reply@.*"
+    """
+
+    __tablename__ = "global_sender_blacklist"
+
+    pattern = sa.Column(sa.String(512), unique=True, nullable=False)
+    enabled = sa.Column(sa.Boolean, nullable=False, default=True, server_default="1")
+    comment = sa.Column(sa.Text, nullable=True)
+
+
 # region Phone
 class PhoneCountry(Base, ModelMixin):
     __tablename__ = "phone_country"

--- a/app/regex_utils.py
+++ b/app/regex_utils.py
@@ -5,7 +5,8 @@ import re2
 from app.log import LOG
 
 
-def regex_match(rule_regex: str, local):
+def regex_match(rule_regex: str, local) -> bool:
+    """Return True if *full string* matches rule_regex."""
     regex = re2.compile(rule_regex)
     try:
         if re2.fullmatch(regex, local):
@@ -14,5 +15,22 @@ def regex_match(rule_regex: str, local):
         LOG.w("use re instead of re2 for %s %s", rule_regex, local)
         regex = re.compile(rule_regex)
         if re.fullmatch(regex, local):
+            return True
+    return False
+
+
+def regex_search(rule_regex: str, text: str) -> bool:
+    """Return True if any substring of text matches rule_regex.
+
+    Uses re2 when possible to avoid catastrophic backtracking.
+    """
+    regex = re2.compile(rule_regex)
+    try:
+        if re2.search(regex, text):
+            return True
+    except TypeError:  # re2 bug "Argument 'pattern' has incorrect type (expected bytes, got PythonRePattern)"
+        LOG.w("use re instead of re2 for %s %s", rule_regex, text)
+        regex = re.compile(rule_regex)
+        if re.search(regex, text):
             return True
     return False

--- a/app/sender_blacklist.py
+++ b/app/sender_blacklist.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from cachetools import TTLCache, cached
+
+from app.db import Session
+from app.log import LOG
+from app.models import GlobalSenderBlacklist
+from app.regex_utils import regex_search
+
+
+# Cache enabled patterns briefly to avoid a DB query per inbound email.
+# Admin changes should take effect quickly but don't need to be instant.
+@cached(cache=TTLCache(maxsize=1, ttl=30))
+def _get_enabled_patterns() -> list[str]:
+    return [
+        r.pattern
+        for r in Session.query(GlobalSenderBlacklist)
+        .filter(GlobalSenderBlacklist.enabled.is_(True))
+        .order_by(GlobalSenderBlacklist.id.asc())
+        .all()
+    ]
+
+
+def is_sender_globally_blocked(*candidates: str) -> bool:
+    """Return True if any candidate sender string matches the global blacklist.
+
+    Typical candidates:
+      - SMTP envelope MAIL FROM
+      - parsed header From address
+    """
+
+    patterns = _get_enabled_patterns()
+    if not patterns:
+        return False
+
+    for candidate in candidates:
+        if not candidate:
+            continue
+        # Ignore bounce/null reverse-path
+        if candidate == "<>":
+            continue
+
+        for pattern in patterns:
+            try:
+                if regex_search(pattern, candidate):
+                    return True
+            except Exception:
+                # Never crash the SMTP handler because of a bad regex.
+                LOG.exception(
+                    "Global sender blacklist regex failed: pattern=%s candidate=%s",
+                    pattern,
+                    candidate,
+                )
+
+    return False

--- a/email_handler.py
+++ b/email_handler.py
@@ -154,6 +154,7 @@ from app.handler.spamd_result import (
 from app.handler.unsubscribe_generator import UnsubscribeGenerator
 from app.handler.unsubscribe_handler import UnsubscribeHandler
 from app.log import LOG, set_message_id
+from app.sender_blacklist import is_sender_globally_blocked
 from app.mail_sender import sl_sendmail
 from app.mailbox_utils import (
     get_mailbox_for_reply_phase,
@@ -659,7 +660,9 @@ def handle_forward(envelope, msg: Message, rcpt_to: str) -> List[Tuple[bool, str
         )
         return [(True, status.E502)]
 
-    if not alias.enabled or alias.is_trashed() or contact.block_forward:
+    sender_blocked = is_sender_globally_blocked(envelope.mail_from, contact.website_email)
+
+    if not alias.enabled or alias.is_trashed() or contact.block_forward or sender_blocked:
         if not alias.enabled:
             LOG.d("%s is disabled, do not forward", alias)
 
@@ -668,6 +671,14 @@ def handle_forward(envelope, msg: Message, rcpt_to: str) -> List[Tuple[bool, str
 
         if contact.block_forward:
             LOG.d("Contact %s of alias %s is blocked, do not forward", contact, alias)
+
+        if sender_blocked:
+            LOG.i(
+                "Sender is blocked by global sender blacklist: mail_from=%s header_from=%s alias=%s",
+                envelope.mail_from,
+                contact.website_email,
+                alias,
+            )
 
         EmailLog.create(
             contact_id=contact.id,

--- a/migrations/versions/2026_0308_b7c1d6a4f2e1_global_sender_blacklist.py
+++ b/migrations/versions/2026_0308_b7c1d6a4f2e1_global_sender_blacklist.py
@@ -1,0 +1,40 @@
+"""Add global sender blacklist
+
+Revision ID: b7c1d6a4f2e1
+Revises: 3ee37864eb67
+Create Date: 2026-03-08
+
+"""
+
+import sqlalchemy_utils
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "b7c1d6a4f2e1"
+down_revision = "3ee37864eb67"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "global_sender_blacklist",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column(
+            "created_at", sqlalchemy_utils.types.arrow.ArrowType(), nullable=False
+        ),
+        sa.Column("updated_at", sqlalchemy_utils.types.arrow.ArrowType(), nullable=True),
+        sa.Column("pattern", sa.String(length=512), nullable=False),
+        sa.Column(
+            "enabled", sa.Boolean(), server_default=sa.text("true"), nullable=False
+        ),
+        sa.Column("comment", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("pattern"),
+    )
+
+
+def downgrade():
+    op.drop_table("global_sender_blacklist")

--- a/tests/test_email_handler.py
+++ b/tests/test_email_handler.py
@@ -24,6 +24,7 @@ from app.models import (
     VerpType,
     Contact,
     SentAlert,
+    GlobalSenderBlacklist,
 )
 from app.utils import random_string, canonicalize_email
 from email_handler import (
@@ -41,6 +42,27 @@ def test_should_ignore(flask_client):
     assert not should_ignore("mail_from", ["rcpt_to"])
     IgnoredEmail.create(mail_from="mail_from", rcpt_to="rcpt_to", commit=True)
     assert should_ignore("mail_from", ["rcpt_to"])
+
+
+def test_global_sender_blacklist_blocks(flask_client):
+    user = create_new_user()
+    alias = Alias.create_new_random(user)
+
+    # Block all senders from spam.test
+    GlobalSenderBlacklist.create(pattern=r"@spam\\.test$", enabled=True, commit=True)
+
+    msg = EmailMessage()
+    msg[headers.FROM] = "Bad Guy <bad@spam.test>"
+    msg[headers.TO] = alias.email
+    msg[headers.SUBJECT] = "hello"
+    msg.set_content("test")
+
+    envelope = Envelope()
+    envelope.mail_from = "bad@spam.test"
+    envelope.rcpt_tos = [alias.email]
+
+    result = email_handler.handle(envelope, msg)
+    assert result == status.E200
 
 
 def test_is_automatic_out_of_office():


### PR DESCRIPTION
Adds a global sender blacklist to SimpleLogin: Admin can block sender addresses (or whole domains / TLDs) by regex pattern.

- New DB table `global_sender_blacklist` (pattern regex + enabled + comment)
- Admin UI (Flask-Admin) to manage patterns
- Inbound SMTP handling: blocks senders matching the blacklist, using the same behavior as a blocked Contact (2xx vs 5xx depending on user.block_behaviour)
- Uses re2-backed regex search to avoid catastrophic backtracking

Example patterns:
- `@spamdomain\.com$`
- `^no-?reply@.*`

Migration and test are included.