### PR TITLE
Several fixes

### DIFF
--- a/app/alias_utils.py
+++ b/app/alias_utils.py
@@ -105,6 +105,12 @@ def check_if_alias_can_be_auto_created_for_custom_domain(
         )
         return None
 
+    if not custom_domain.ownership_verified:
+        LOG.i(
+            f"Custom domain {custom_domain} is not verified so we cannot auto-create alias for {address}"
+        )
+        return None
+
     user: User = custom_domain.user
     if user.disabled:
         LOG.i("Disabled user %s can't create new alias via custom domain", user)

--- a/app/auth/views/fido.py
+++ b/app/auth/views/fido.py
@@ -160,11 +160,8 @@ def fido():
     fido_by_credential_id = {fido.credential_id: fido for fido in fidos}
     for credential in webauthn_assertion_options.get("allowCredentials", []):
         fido = fido_by_credential_id.get(credential.get("id"))
-        if fido and fido.transports:
-            try:
-                credential["transports"] = json.loads(fido.transports)
-            except Exception:
-                del credential["transports"]
+        if fido and isinstance(fido.transports, list) and fido.transports:
+            credential["transports"] = fido.transports
         else:
             credential.pop("transports", None)
 

--- a/email_handler.py
+++ b/email_handler.py
@@ -31,29 +31,29 @@ It should contain the following info:
 
 """
 
+from email import encoders
+
 import argparse
 import email
+import newrelic.agent
+import sentry_sdk
+import time
 import uuid
-from email import encoders
+from aiosmtpd.controller import Controller
+from aiosmtpd.smtp import Envelope
 from email.encoders import encode_noop
 from email.message import Message
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.utils import make_msgid, formatdate, getaddresses
-from io import BytesIO
-from smtplib import SMTPRecipientsRefused, SMTPServerDisconnected
-from typing import List, Tuple, Optional, Set
-
-import newrelic.agent
-import sentry_sdk
-import time
-from aiosmtpd.controller import Controller
-from aiosmtpd.smtp import Envelope
 from email_validator import validate_email, EmailNotValidError
 from flanker.addresslib import address
 from flanker.addresslib.address import EmailAddress
+from io import BytesIO
 from sl_pgp import PgpContext
+from smtplib import SMTPRecipientsRefused, SMTPServerDisconnected
 from sqlalchemy.exc import IntegrityError
+from typing import List, Tuple, Optional, Set
 
 from app import pgp_utils, s3, config, contact_utils
 from app.alias_utils import (
@@ -78,12 +78,9 @@ from app.config import (
     PGP_SENDER_PRIVATE_KEY,
     ALERT_BOUNCE_EMAIL_REPLY_PHASE,
     NOREPLY,
-    BOUNCE_PREFIX,
-    BOUNCE_SUFFIX,
     TRANSACTIONAL_BOUNCE_PREFIX,
     TRANSACTIONAL_BOUNCE_SUFFIX,
     ENABLE_SPAM_ASSASSIN,
-    BOUNCE_PREFIX_FOR_REPLY_PHASE,
     POSTMASTER,
     OLD_UNSUBSCRIBER,
     ALERT_FROM_ADDRESS_IS_REVERSE_ALIAS,
@@ -2153,11 +2150,7 @@ def handle(envelope: Envelope, msg: Message) -> str:
             raise VERPTransactional
 
     # sent to forward VERP, can be either bounce or out-of-office
-    if (
-        len(rcpt_tos) == 1
-        and rcpt_tos[0].startswith(BOUNCE_PREFIX)
-        and rcpt_tos[0].endswith(BOUNCE_SUFFIX)
-    ) or (verp_info and verp_info[0] == VerpType.bounce_forward):
+    if verp_info and verp_info[0] == VerpType.bounce_forward:
         email_log_id = (verp_info and verp_info[1]) or parse_id_from_bounce(rcpt_tos[0])
         email_log = EmailLog.get(email_log_id)
 
@@ -2173,11 +2166,7 @@ def handle(envelope: Envelope, msg: Message) -> str:
             raise VERPForward
 
     # sent to reply VERP, can be either bounce or out-of-office
-    if (
-        len(rcpt_tos) == 1
-        and rcpt_tos[0].startswith(f"{BOUNCE_PREFIX_FOR_REPLY_PHASE}+")
-        or (verp_info and verp_info[0] == VerpType.bounce_reply)
-    ):
+    if len(rcpt_tos) == 1 and verp_info and verp_info[0] == VerpType.bounce_reply:
         email_log_id = (verp_info and verp_info[1]) or parse_id_from_bounce(rcpt_tos[0])
         email_log = EmailLog.get(email_log_id)
 
@@ -2196,13 +2185,13 @@ def handle(envelope: Envelope, msg: Message) -> str:
                 f"{email_log.alias} -> {email_log.contact} ({email_log}, {email_log.user}"
             )
 
-    # iCloud returns the bounce with mail_from=bounce+{email_log_id}+@simplelogin.co, rcpt_to=alias
-    verp_info = get_verp_info_from_email(mail_from[0])
+    verp_info = get_verp_info_from_email(mail_from)
     if (
         len(rcpt_tos) == 1
-        and mail_from.startswith(BOUNCE_PREFIX)
-        and mail_from.endswith(BOUNCE_SUFFIX)
-    ) or (verp_info and verp_info[0] == VerpType.bounce_forward):
+        and verp_info
+        and verp_info[0] == VerpType.bounce_forward
+        and is_bounce(envelope, msg)
+    ):
         email_log_id = (verp_info and verp_info[1]) or parse_id_from_bounce(mail_from)
         email_log = EmailLog.get(email_log_id)
         alias = Alias.get_by(email=rcpt_tos[0])

--- a/tests/test_alias_utils.py
+++ b/tests/test_alias_utils.py
@@ -3,6 +3,7 @@ from typing import List
 from app.alias_delete import delete_alias
 from app.alias_utils import (
     check_alias_prefix,
+    check_if_alias_can_be_auto_created_for_custom_domain,
     get_user_if_alias_would_auto_create,
     get_alias_recipient_name,
     try_auto_create,
@@ -65,6 +66,7 @@ def get_auto_create_alias_tests(user: User) -> List:
         catch_all=True,
         domain=random_domain(),
         verified=True,
+        ownership_verified=True,
         flush=True,
     )
     no_catchall = CustomDomain.create(
@@ -72,6 +74,7 @@ def get_auto_create_alias_tests(user: User) -> List:
         catch_all=False,
         domain=random_domain(),
         verified=True,
+        ownership_verified=True,
         flush=True,
     )
     no_catchall_with_rule = CustomDomain.create(
@@ -79,6 +82,7 @@ def get_auto_create_alias_tests(user: User) -> List:
         catch_all=False,
         domain=random_domain(),
         verified=True,
+        ownership_verified=True,
         flush=True,
     )
     AutoCreateRule.create(
@@ -143,6 +147,7 @@ def test_auto_create_alias_applies_rule_display_name(flask_client):
         catch_all=False,
         domain=random_domain(),
         verified=True,
+        ownership_verified=True,
         flush=True,
     )
     rule = AutoCreateRule.create(
@@ -253,3 +258,22 @@ def test_get_alias_recipient_alias_without_name_and_custom_domain_name():
     res = get_alias_recipient_name(alias)
     assert res.message is not None
     assert res.name == f"{custom_domain.name} <{alias.email}>"
+
+
+def test_check_if_alias_can_be_auto_created_for_unverified_domain(flask_client):
+    user = create_new_user()
+    user.lifetime = True
+    custom_domain = CustomDomain.create(
+        user_id=user.id,
+        catch_all=True,
+        domain=random_domain(),
+        verified=True,
+        ownership_verified=False,
+        flush=True,
+    )
+    Session.commit()
+
+    result = check_if_alias_can_be_auto_created_for_custom_domain(
+        f"anything@{custom_domain.domain}"
+    )
+    assert result is None


### PR DESCRIPTION
This MR has several fixes:
 - Only rely on new VERP signed address. Deprecate old bounce system.
 - For FIDO authentication rely on the json deserialization of sqlalchemy. It is directly an object
 - Only create alias for domains that have the ownership verified.