### PR TITLE
docs: update self-hosting guide with current Docker image and migration command

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,10 @@ Setting up DKIM is highly recommended to reduce the chance your emails ending up
 First you need to generate a private and public key for DKIM:
 
 ```bash
-openssl genrsa -out dkim.key -traditional 1024
+openssl genrsa -out dkim.key -traditional 1024 2>/dev/null || openssl genrsa -out dkim.key 1024
 openssl rsa -in dkim.key -pubout -out dkim.pub.key
 ```
+> **Note:** If you are using OpenSSL 3.x (e.g., Ubuntu 22.04+), the `-traditional` flag is required to generate a PKCS#1 key compatible with SimpleLogin. If you receive an error, ensure you are using OpenSSL 1.x or install it via `sudo apt install openssl1.0`.
 
 You will need the files `dkim.key` and `dkim.pub.key` for the next steps.
 
@@ -434,7 +435,7 @@ docker run --rm \
     -v $(pwd)/dkim.pub.key:/dkim.pub.key \
     -v $(pwd)/simplelogin.env:/code/.env \
     --network="sl-network" \
-    simplelogin/app:3.4.0 flask db upgrade
+    simplelogin/app:latest alembic upgrade head
 ```
 
 This command could take a while to download the `simplelogin/app` docker image.
@@ -449,7 +450,7 @@ docker run --rm \
     -v $(pwd)/dkim.key:/dkim.key \
     -v $(pwd)/dkim.pub.key:/dkim.pub.key \
     --network="sl-network" \
-    simplelogin/app:3.4.0 python init_app.py
+    simplelogin/app:latest python init_app.py
 ```
 
 Now, it's time to run the `webapp` container!
@@ -465,7 +466,7 @@ docker run -d \
     -p 127.0.0.1:7777:7777 \
     --restart always \
     --network="sl-network" \
-    simplelogin/app:3.4.0
+    simplelogin/app:latest
 ```
 
 Next run the `email handler`
@@ -481,7 +482,7 @@ docker run -d \
     -p 127.0.0.1:20381:20381 \
     --restart always \
     --network="sl-network" \
-    simplelogin/app:3.4.0 python email_handler.py
+    simplelogin/app:latest python email_handler.py
 ```
 
 And finally the `job runner`
@@ -496,7 +497,7 @@ docker run -d \
     -v $(pwd)/dkim.pub.key:/dkim.pub.key \
     --restart always \
     --network="sl-network" \
-    simplelogin/app:3.4.0 python job_runner.py
+    simplelogin/app:latest python job_runner.py
 ```
 
 ### Nginx


### PR DESCRIPTION
Fixes #1205

This PR updates the outdated self-hosting guide in README.md:

- Replace deprecated `simplelogin/app:3.4.0` Docker image tag with `simplelogin/app:latest`
- Update database migration command from `flask db upgrade` to `alembic upgrade head` (required for newer versions)
- Add a note about OpenSSL 3.x compatibility for DKIM key generation on Ubuntu 22.04+