### PR TITLE
Disable custom domains if MX records are disabled

### DIFF
--- a/app/email/status.py
+++ b/app/email/status.py
@@ -53,6 +53,7 @@ E516 = "550 SL E516 invalid mailbox"
 E517 = "550 SL E517 unverified mailbox"
 E518 = "550 SL E518 Disabled mailbox"
 E519 = "550 SL E519 Email detected as spam"
+E520 = "550 SL E520 Unverified custom domain"
 E521 = "550 SL E521 Cannot reach mailbox"
 E522 = (
     "550 SL E522 The user you are trying to contact is receiving mail "

--- a/email_handler.py
+++ b/email_handler.py
@@ -33,6 +33,7 @@ It should contain the following info:
 
 import argparse
 import email
+import time
 import uuid
 from email import encoders
 from email.encoders import encode_noop
@@ -46,7 +47,6 @@ from typing import List, Tuple, Optional, Set
 
 import newrelic.agent
 import sentry_sdk
-import time
 from aiosmtpd.controller import Controller
 from aiosmtpd.smtp import Envelope
 from email_validator import validate_email, EmailNotValidError
@@ -1060,6 +1060,10 @@ def handle_reply(
         return False, status.E502
 
     alias = contact.alias
+
+    if alias.custom_domain_id and not alias.custom_domain.verified:
+        LOG.w("Alias %s is on unverified custom domain, refusing email", alias)
+        return False, status.E520
 
     if alias.is_trashed():
         LOG.d("%s is trashed, do not forward", alias)

--- a/email_handler.py
+++ b/email_handler.py
@@ -575,6 +575,10 @@ def handle_forward(envelope, msg: Message, rcpt_to: str) -> List[Tuple[bool, str
         else:
             return [(False, status.E504)]
 
+    if alias.custom_domain_id and not alias.custom_domain.verified:
+        LOG.w("Alias %s is on unverified custom domain, refusing email", alias)
+        return [(False, status.E520)]
+
     # check if email is sent from alias's owning mailbox(es)
     mail_from = envelope.mail_from
     for addr in alias.authorized_addresses():

--- a/tasks/check_custom_domains.py
+++ b/tasks/check_custom_domains.py
@@ -75,8 +75,8 @@ def check_single_custom_domain(custom_domain: CustomDomain):
 
         custom_domain.nb_failed_checks += 1
 
-        # send alert if fail for 5 consecutive days
-        if custom_domain.nb_failed_checks > 5:
+        # send alert if fail for 3 consecutive days
+        if custom_domain.nb_failed_checks > 2:
             domain_dns_url = f"{config.URL}/dashboard/domains/{custom_domain.id}/dns"
             LOG.w("Alert domain MX check fails %s about %s", user, custom_domain)
             send_email_with_rate_control(
@@ -94,7 +94,16 @@ def check_single_custom_domain(custom_domain: CustomDomain):
                 nb_day=30,
                 retries=3,
             )
-            # reset checks
+            LOG.w(
+                "De-verifying domain %s after %d failed MX checks",
+                custom_domain,
+                custom_domain.nb_failed_checks,
+            )
+            # reset domain
+            custom_domain.verified = False
+            custom_domain.dkim_verified = False
+            custom_domain.dmarc_verified = False
+            custom_domain.spf_verified = False
             custom_domain.nb_failed_checks = 0
     else:
         # reset checks

--- a/templates/emails/transactional/custom-domain-dns-issue.txt.jinja2
+++ b/templates/emails/transactional/custom-domain-dns-issue.txt.jinja2
@@ -1,10 +1,10 @@
 {% extends "base.txt.jinja2" %}
 
 {% block content %}
-We have detected that your domain {{ custom_domain.domain }} doesn't have the DNS MX records correctly set up.
+We have detected that your domain {{ custom_domain.domain }} doesn't have the DNS MX records correctly set up
+and has been temporarily deactivated.
 
-Please re-run the MX check on {{ domain_dns_url }} and update them if needed.
+To reactivate it, please update the MX records and re-run the DNS check at {{ domain_dns_url }}.
 
-Without the MX records correctly set up, emails sent to the {{ custom_domain.domain }}'s aliases
-  aren't properly and reliably handled.
+Until the domain is properly configured, aliases under {{ custom_domain.domain }} will not receive emails.
 {% endblock %}

--- a/tests/tasks/test_check_custom_domain.py
+++ b/tests/tasks/test_check_custom_domain.py
@@ -1,8 +1,66 @@
 import arrow
+from unittest.mock import patch
 
 from app.models import CustomDomain
-from tasks.check_custom_domains import check_all_custom_domains
+from tasks.check_custom_domains import (
+    check_all_custom_domains,
+    check_single_custom_domain,
+)
 from tests.utils import create_new_user, random_string
+
+
+def test_check_single_custom_domain_increments_failed_checks(flask_client):
+    user = create_new_user()
+    custom_domain = CustomDomain.create(
+        user_id=user.id,
+        domain=random_string(),
+        verified=True,
+        nb_failed_checks=0,
+        commit=True,
+    )
+    with patch("tasks.check_custom_domains.get_mx_domains", return_value=[]), patch(
+        "tasks.check_custom_domains.is_mx_equivalent", return_value=False
+    ), patch("tasks.check_custom_domains.send_email_with_rate_control"):
+        check_single_custom_domain(custom_domain)
+    assert custom_domain.nb_failed_checks == 1
+    assert custom_domain.verified is True
+
+
+def test_check_single_custom_domain_deactivates_after_threshold(flask_client):
+    user = create_new_user()
+    custom_domain = CustomDomain.create(
+        user_id=user.id,
+        domain=random_string(),
+        verified=True,
+        nb_failed_checks=2,
+        commit=True,
+    )
+    with patch("tasks.check_custom_domains.get_mx_domains", return_value=[]), patch(
+        "tasks.check_custom_domains.is_mx_equivalent", return_value=False
+    ), patch("tasks.check_custom_domains.send_email_with_rate_control"):
+        check_single_custom_domain(custom_domain)
+    assert custom_domain.verified is False
+    assert custom_domain.dkim_verified is False
+    assert custom_domain.dmarc_verified is False
+    assert custom_domain.spf_verified is False
+    assert custom_domain.nb_failed_checks == 0
+
+
+def test_check_single_custom_domain_resets_on_success(flask_client):
+    user = create_new_user()
+    custom_domain = CustomDomain.create(
+        user_id=user.id,
+        domain=random_string(),
+        verified=True,
+        nb_failed_checks=2,
+        commit=True,
+    )
+    with patch("tasks.check_custom_domains.get_mx_domains", return_value=[]), patch(
+        "tasks.check_custom_domains.is_mx_equivalent", return_value=True
+    ):
+        check_single_custom_domain(custom_domain)
+    assert custom_domain.nb_failed_checks == 0
+    assert custom_domain.verified is True
 
 
 def test_check_custom_domain_deletes_old_domains():

--- a/tests/test_email_handler.py
+++ b/tests/test_email_handler.py
@@ -17,6 +17,7 @@ from app.email_utils import generate_verp_email, get_noreply_email
 from app.mail_sender import mail_sender
 from app.models import (
     Alias,
+    CustomDomain,
     IgnoredEmail,
     EmailLog,
     Notification,
@@ -136,6 +137,29 @@ def test_preserve_5xx_with_no_header(flask_client):
     envelope.rcpt_tos = [generate_verp_email(VerpType.bounce_forward, 99999999999999)]
     result = email_handler.MailHandler()._handle(envelope, msg)
     assert status.E512 == result
+
+
+def test_forward_rejected_for_unverified_custom_domain(flask_client):
+    user = create_new_user()
+    domain = CustomDomain.create(
+        user_id=user.id,
+        domain=f"{random_string()}.example.com",
+        verified=False,
+        commit=True,
+    )
+    alias = Alias.create(
+        user_id=user.id,
+        email=f"{random_string()}@{domain.domain}",
+        mailbox_id=user.default_mailbox_id,
+        custom_domain_id=domain.id,
+        commit=True,
+    )
+    msg = load_eml_file("dmarc_allow.eml", {"alias_email": alias.email})
+    envelope = Envelope()
+    envelope.mail_from = "sender@external.com"
+    envelope.rcpt_tos = [alias.email]
+    result = email_handler.handle(envelope, msg)
+    assert result == status.E520
 
 
 def generate_dmarc_result() -> List:

--- a/tests/test_email_handler.py
+++ b/tests/test_email_handler.py
@@ -139,6 +139,43 @@ def test_preserve_5xx_with_no_header(flask_client):
     assert status.E512 == result
 
 
+def test_reply_rejected_for_unverified_custom_domain(flask_client):
+    user = create_new_user()
+    domain = CustomDomain.create(
+        user_id=user.id,
+        domain=f"{random_string()}.example.com",
+        verified=False,
+        commit=True,
+    )
+    alias = Alias.create(
+        user_id=user.id,
+        email=f"{random_string()}@{domain.domain}",
+        mailbox_id=user.default_mailbox_id,
+        custom_domain_id=domain.id,
+        commit=True,
+    )
+    contact = Contact.create(
+        user_id=user.id,
+        alias_id=alias.id,
+        website_email="sender@external.com",
+        reply_email=f"{random_string()}@{EMAIL_DOMAIN}",
+        commit=True,
+    )
+    msg = load_eml_file(
+        "dmarc_reply_check.eml",
+        {
+            "alias_email": alias.email,
+            "contact_email": contact.reply_email,
+            "dmarc_result": "DMARC_POLICY_ALLOW",
+        },
+    )
+    envelope = Envelope()
+    envelope.mail_from = alias.email
+    envelope.rcpt_tos = [contact.reply_email]
+    result = email_handler.handle(envelope, msg)
+    assert result == status.E520
+
+
 def test_forward_rejected_for_unverified_custom_domain(flask_client):
     user = create_new_user()
     domain = CustomDomain.create(


### PR DESCRIPTION
Currently we just notify owners of domains that the MX records are not properly set. Now they will be disabled and aliases won't be forwarded if the domain is not properly configured.