### PR TITLE
Add the original unsub behaviour information as a header

### DIFF
--- a/app/email/headers.py
+++ b/app/email/headers.py
@@ -42,6 +42,7 @@ SL_CLIENT_IP = "X-SimpleLogin-Client-IP"
 SL_ORIGINAL_LIST_UNSUBSCRIBE = "X-SimpleLogin-Original-List-Unsubscribe"
 SL_ORIGINAL_LIST_UNSUBSCRIBE_POST = "X-SimpleLogin-Original-List-Unsubscribe-Post"
 SL_ORIGINAL_LIST_ID = "X-SimpleLogin-Original-List-Id"
+SL_UNSUB_BEHAVIOUR = "X-SimpleLogin-Unsub-Behaviour"
 
 # to let Rspamd know that the message should be signed
 SL_WANT_SIGNING = "X-SimpleLogin-Want-Signing"

--- a/app/handler/unsubscribe_generator.py
+++ b/app/handler/unsubscribe_generator.py
@@ -15,6 +15,20 @@ from app.log import LOG
 from app.models import Alias, Contact, UnsubscribeBehaviourEnum
 
 
+def _behaviour_to_header_value(behaviour: UnsubscribeBehaviourEnum) -> str | None:
+    """Convert UnsubscribeBehaviourEnum to header value."""
+    match behaviour:
+        case UnsubscribeBehaviourEnum.DisableAlias:
+            return "alias-disable"
+        case UnsubscribeBehaviourEnum.BlockContact:
+            return "contact-block"
+        case UnsubscribeBehaviourEnum.PreserveOriginal:
+            return "original-behaviour"
+        case _:
+            LOG.error(f"Unknown unsubscribe behaviour: {behaviour}")
+            return None
+
+
 class UnsubscribeGenerator:
     def _calculate_header_with_original_behaviour(
         self, alias: Alias, message: Message, force_web: bool = False
@@ -119,6 +133,7 @@ class UnsubscribeGenerator:
     ) -> Message:
         """
         Add List-Unsubscribe header based on the user preference.
+        Also adds X-SimpleLogin-Unsub-Behaviour header to indicate the unsubscribe behaviour.
         """
         force_web = False
         if alias.user_id in config.USERS_WITH_HTTP_UNSUBSCRIBE:
@@ -130,13 +145,18 @@ class UnsubscribeGenerator:
         )
         message = self.__preserve_original_headers(message, original_unsub_proxied)
         if unsub_behaviour == UnsubscribeBehaviourEnum.PreserveOriginal:
-            return self.__replace_unsub_headers(message, original_unsub_proxied)
+            message = self.__replace_unsub_headers(message, original_unsub_proxied)
         elif unsub_behaviour == UnsubscribeBehaviourEnum.DisableAlias:
             unsub = UnsubscribeData(UnsubscribeAction.DisableAlias, alias.id)
-            return self._add_unsubscribe_header(message, unsub, force_web=force_web)
+            message = self._add_unsubscribe_header(message, unsub, force_web=force_web)
         else:
             unsub = UnsubscribeData(UnsubscribeAction.DisableContact, contact.id)
-            return self._add_unsubscribe_header(message, unsub, force_web=force_web)
+            message = self._add_unsubscribe_header(message, unsub, force_web=force_web)
+
+        header_value = _behaviour_to_header_value(unsub_behaviour)
+        if header_value:
+            add_or_replace_header(message, headers.SL_UNSUB_BEHAVIOUR, header_value)
+        return message
 
     def __preserve_original_headers(
         self, message: Message, original_unsub_proxied: dict[str, str]

--- a/tests/handler/test_unsubscribe_generator.py
+++ b/tests/handler/test_unsubscribe_generator.py
@@ -76,6 +76,7 @@ def test_unsub_disable_contact(
     else:
         assert "List-Unsubscribe=One-Click" == message[headers.LIST_UNSUBSCRIBE_POST]
     assert message[headers.SL_ORIGINAL_LIST_UNSUBSCRIBE] == original_header
+    assert message[headers.SL_UNSUB_BEHAVIOUR] == "contact-block"
 
 
 def generate_unsub_disable_alias_data() -> Iterable:
@@ -136,6 +137,7 @@ def test_unsub_disable_alias(
     else:
         assert "List-Unsubscribe=One-Click" == message[headers.LIST_UNSUBSCRIBE_POST]
     assert message[headers.SL_ORIGINAL_LIST_UNSUBSCRIBE] == original_header
+    assert message[headers.SL_UNSUB_BEHAVIOUR] == "alias-disable"
 
 
 def generate_unsub_preserve_original_data() -> Iterable:
@@ -214,6 +216,7 @@ def test_unsub_preserve_original(
         == message[f"X-SL-Proxy-{headers.LIST_UNSUBSCRIBE}"]
     )
     assert message[headers.SL_ORIGINAL_LIST_UNSUBSCRIBE] == original_header
+    assert message[headers.SL_UNSUB_BEHAVIOUR] == "original-behaviour"
 
 
 def test_unsub_preserves_sl_unsubscriber():
@@ -235,6 +238,7 @@ def test_unsub_preserves_sl_unsubscriber():
     message = UnsubscribeGenerator().add_header_to_message(alias, contact, message)
     assert original_header == message[headers.LIST_UNSUBSCRIBE]
     assert message[headers.SL_ORIGINAL_LIST_UNSUBSCRIBE] == original_header
+    assert message[headers.SL_UNSUB_BEHAVIOUR] == "original-behaviour"
 
 
 def test_unsub_preserves_nothing_if_there_is_no_original_unsub():
@@ -253,6 +257,7 @@ def test_unsub_preserves_nothing_if_there_is_no_original_unsub():
     message = UnsubscribeGenerator().add_header_to_message(alias, contact, message)
     assert message[headers.SL_ORIGINAL_LIST_UNSUBSCRIBE] is None
     assert message[headers.SL_ORIGINAL_LIST_UNSUBSCRIBE_POST] is None
+    assert message[headers.SL_UNSUB_BEHAVIOUR] == "original-behaviour"
 
 
 def test_unsub_preserves_original():
@@ -276,3 +281,4 @@ def test_unsub_preserves_original():
     assert (
         message[headers.SL_ORIGINAL_LIST_UNSUBSCRIBE_POST] == original_header + "post"
     )
+    assert message[headers.SL_UNSUB_BEHAVIOUR] == "original-behaviour"


### PR DESCRIPTION
Set the configured behaviour in an extra header so clients can react downstream.