### PR TITLE
Escape emails individually

### DIFF
--- a/app/email_utils.py
+++ b/app/email_utils.py
@@ -33,7 +33,7 @@ from email_validator import (
 from flanker.addresslib import address
 from flanker.addresslib.address import EmailAddress
 from flask_login import current_user
-from jinja2 import Environment, FileSystemLoader, select_autoescape
+from jinja2 import Environment, FileSystemLoader
 from sqlalchemy import func
 
 from app import config
@@ -93,9 +93,7 @@ def get_noreply_domain(user=None) -> str:
 
 def render(template_name: str, user: Optional[User], **kwargs) -> str:
     templates_dir = os.path.join(config.ROOT_DIR, "templates", "emails")
-    env = Environment(
-        loader=FileSystemLoader(templates_dir), autoescape=select_autoescape(["html"])
-    )
+    env = Environment(loader=FileSystemLoader(templates_dir))
 
     template = env.get_template(template_name)
 

--- a/templates/emails/com/newsletter/pgp.html
+++ b/templates/emails/com/newsletter/pgp.html
@@ -16,7 +16,7 @@
        style="max-width: 100%">
   {{ render_text("You can find more info on our announcement post on https://simplelogin.io/blog/introducing-pgp/") }}
   {{ render_text("You can create and manage your PGP keys when adding or editing your mailboxes. Check it out on your mailbox dashboard.") }}
-  {{ render_button("Add your PGP key", URL ~ "/dashboard/mailbox") }}
+  {{ render_button("Add your PGP key", URL + "/dashboard/mailbox") }}
   {{ render_text("Our next important feature is the coming of an iOS app. If you use iPhone or iPad want to help us testing out the app, please reply to this email so we can add you into the TestFlight program.
     ") }}
   {{ render_text("For Android users, don't worry: the Android version is already in progress.

--- a/templates/emails/com/onboarding/mailbox.html
+++ b/templates/emails/com/onboarding/mailbox.html
@@ -29,8 +29,8 @@
     Please note that adding additional mailboxes is only available in the Premium plan.
   {% endcall %}
 
-  {{ render_button("Create mailbox", URL ~ "/dashboard/mailbox") }}
-  {{ raw_url(URL ~ "/dashboard/mailbox") }}
+  {{ render_button("Create mailbox", URL + "/dashboard/mailbox") }}
+  {{ raw_url(URL + "/dashboard/mailbox") }}
 {% endblock %}
 {% block footer %}
 

--- a/templates/emails/com/onboarding/pgp.html
+++ b/templates/emails/com/onboarding/pgp.html
@@ -29,8 +29,8 @@
        alt="Without PGP"
        style="max-width: 100%;
               margin-bottom: 20px">
-  {{ render_button("Enable PGP on your mailbox", URL ~ "/dashboard/mailbox/" ~ user.default_mailbox_id) }}
-  {{ raw_url(URL ~ "/dashboard/mailbox/" ~ user.default_mailbox_id) }}
+  {{ render_button("Enable PGP on your mailbox", URL + "/dashboard/mailbox/" + user.default_mailbox_id) }}
+  {{ raw_url(URL + "/dashboard/mailbox/" + user.default_mailbox_id) }}
 {% endblock %}
 {% block footer %}
 

--- a/templates/emails/transactional/activation.html
+++ b/templates/emails/transactional/activation.html
@@ -3,7 +3,7 @@
 {% block content %}
 
   {{ render_text("Thank you for choosing SimpleLogin.") }}
-  {{ render_text("To get started, please confirm that <b>" + email + "</b> is your email address by clicking on the button below within 1 hour.") }}
+  {{ render_text("To get started, please confirm that <b>" ~ (email | safe) ~ "</b> is your email address by clicking on the button below within 1 hour.") }}
   {{ render_text("If it wasn't you, maybe someone entered your email by mistake. In this case you can ignore this mail.") }}
   {{ render_button("Verify email", activation_link) }}
   {{ render_text('Thanks,

--- a/templates/emails/transactional/activation.html
+++ b/templates/emails/transactional/activation.html
@@ -3,7 +3,7 @@
 {% block content %}
 
   {{ render_text("Thank you for choosing SimpleLogin.") }}
-  {{ render_text("To get started, please confirm that <b>" ~ (email | safe) ~ "</b> is your email address by clicking on the button below within 1 hour.") }}
+  {{ render_text("To get started, please confirm that <b>" + (email | safe) + "</b> is your email address by clicking on the button below within 1 hour.") }}
   {{ render_text("If it wasn't you, maybe someone entered your email by mistake. In this case you can ignore this mail.") }}
   {{ render_button("Verify email", activation_link) }}
   {{ render_text('Thanks,

--- a/templates/emails/transactional/cannot-create-alias-directory.html
+++ b/templates/emails/transactional/cannot-create-alias-directory.html
@@ -6,7 +6,7 @@
     <h1>Cannot create alias {{ alias }} on-the-fly</h1>
   {% endcall %}
 
-  {{ render_text("An email has been sent to the alias <b>" + alias + "</b> that would be created automatically as you own the directory <b>" + directory + "</b>.") }}
+  {{ render_text("An email has been sent to the alias <b>" ~ (alias | safe) ~ "</b> that would be created automatically as you own the directory <b>" ~ (directory | safe) ~ "</b>.") }}
   {{ render_text("However you have reached the alias limit in your current plan, this creation cannot happen.") }}
   {{ render_text("Please upgrade to premium plan in order to use this feature.") }}
   {{ render_text('Thanks,

--- a/templates/emails/transactional/cannot-create-alias-directory.html
+++ b/templates/emails/transactional/cannot-create-alias-directory.html
@@ -6,7 +6,7 @@
     <h1>Cannot create alias {{ alias }} on-the-fly</h1>
   {% endcall %}
 
-  {{ render_text("An email has been sent to the alias <b>" ~ (alias | safe) ~ "</b> that would be created automatically as you own the directory <b>" ~ (directory | safe) ~ "</b>.") }}
+  {{ render_text("An email has been sent to the alias <b>" + (alias | safe) + "</b> that would be created automatically as you own the directory <b>" + (directory | safe) + "</b>.") }}
   {{ render_text("However you have reached the alias limit in your current plan, this creation cannot happen.") }}
   {{ render_text("Please upgrade to premium plan in order to use this feature.") }}
   {{ render_text('Thanks,

--- a/templates/emails/transactional/cannot-create-alias-domain.html
+++ b/templates/emails/transactional/cannot-create-alias-domain.html
@@ -6,7 +6,7 @@
     <h1>Cannot create {{ alias }} on-the-fly</h1>
   {% endcall %}
 
-  {{ render_text("An email has been sent to the alias <b>" + alias + "</b> that would be created automatically as you own the domain <b>" + domain + "</b>.") }}
+  {{ render_text("An email has been sent to the alias <b>" ~ (alias | safe) ~ "</b> that would be created automatically as you own the domain <b>" ~ (domain | safe) ~ "</b>.") }}
   {{ render_text("However you have reached the alias limit in your current plan, this creation cannot happen.") }}
   {{ render_text("Please upgrade to premium plan in order to use this feature.") }}
   {{ render_text('Thanks,

--- a/templates/emails/transactional/cannot-create-alias-domain.html
+++ b/templates/emails/transactional/cannot-create-alias-domain.html
@@ -6,7 +6,7 @@
     <h1>Cannot create {{ alias }} on-the-fly</h1>
   {% endcall %}
 
-  {{ render_text("An email has been sent to the alias <b>" ~ (alias | safe) ~ "</b> that would be created automatically as you own the domain <b>" ~ (domain | safe) ~ "</b>.") }}
+  {{ render_text("An email has been sent to the alias <b>" + (alias | safe) + "</b> that would be created automatically as you own the domain <b>" + (domain | safe) + "</b>.") }}
   {{ render_text("However you have reached the alias limit in your current plan, this creation cannot happen.") }}
   {{ render_text("Please upgrade to premium plan in order to use this feature.") }}
   {{ render_text('Thanks,

--- a/templates/emails/transactional/change-email.html
+++ b/templates/emails/transactional/change-email.html
@@ -2,8 +2,8 @@
 
 {% block content %}
 
-  {{ render_text("You recently requested to change your email on SimpleLogin to <b>" ~ (new_email | safe) ~ "</b>.") }}
-  {{ render_text("Your current email is " ~ (current_email | safe) ~ ".") }}
+  {{ render_text("You recently requested to change your email on SimpleLogin to <b>" + (new_email | safe) + "</b>.") }}
+  {{ render_text("Your current email is " + (current_email | safe) + ".") }}
   {{ render_text("Use the button below to confirm within the next 12 hours.") }}
   {{ render_button("Change email", link) }}
   {{ render_text('Thanks,

--- a/templates/emails/transactional/change-email.html
+++ b/templates/emails/transactional/change-email.html
@@ -2,8 +2,8 @@
 
 {% block content %}
 
-  {{ render_text("You recently requested to change your email on SimpleLogin to <b>"+ new_email +"</b>.") }}
-  {{ render_text("Your current email is " + current_email + ".") }}
+  {{ render_text("You recently requested to change your email on SimpleLogin to <b>" ~ (new_email | safe) ~ "</b>.") }}
+  {{ render_text("Your current email is " ~ (current_email | safe) ~ ".") }}
   {{ render_text("Use the button below to confirm within the next 12 hours.") }}
   {{ render_button("Change email", link) }}
   {{ render_text('Thanks,

--- a/templates/emails/transactional/code-activation.html
+++ b/templates/emails/transactional/code-activation.html
@@ -6,7 +6,7 @@
   {{ render_text("Thank you for choosing SimpleLogin.") }}
   {{ render_text("To get started, please activate your account by entering the following code into the application:") }}
   {{ render_text("
-    <h1>" + code + "</h1>
+    <h1>" ~ (code | safe) ~ "</h1>
     ") }}
   {{ render_text('Thanks,
     <br />

--- a/templates/emails/transactional/code-activation.html
+++ b/templates/emails/transactional/code-activation.html
@@ -6,7 +6,7 @@
   {{ render_text("Thank you for choosing SimpleLogin.") }}
   {{ render_text("To get started, please activate your account by entering the following code into the application:") }}
   {{ render_text("
-    <h1>" ~ (code | safe) ~ "</h1>
+    <h1>" + (code | safe) + "</h1>
     ") }}
   {{ render_text('Thanks,
     <br />

--- a/templates/emails/transactional/invalid-totp-login.html
+++ b/templates/emails/transactional/invalid-totp-login.html
@@ -3,11 +3,11 @@
 {% block content %}
 
   {{ render_text("There has been an unsuccessful attempt to login to your SimpleLogin account.") }}
-  {{ render_text("An invalid " ~ (type | safe) ~ " code was provided <b>but the email and password were correct.</b>") }}
+  {{ render_text("An invalid " + (type | safe) + " code was provided <b>but the email and password were correct.</b>") }}
   {{ render_text("This request has been blocked. However, if this was <b>not</b> you, please <b>change your password immediately.</b>") }}
-  {{ render_button("Change your password", URL ~ "/dashboard/setting#change_password") }}
+  {{ render_button("Change your password", URL + "/dashboard/setting#change_password") }}
   {{ render_text('Thanks,
     <br />
     SimpleLogin Team.') }}
-  {{ raw_url(URL ~ "/dashboard/setting#change_password") }}
+  {{ raw_url(URL + "/dashboard/setting#change_password") }}
 {% endblock %}

--- a/templates/emails/transactional/invalid-totp-login.html
+++ b/templates/emails/transactional/invalid-totp-login.html
@@ -3,7 +3,7 @@
 {% block content %}
 
   {{ render_text("There has been an unsuccessful attempt to login to your SimpleLogin account.") }}
-  {{ render_text("An invalid " ~ type ~ " code was provided <b>but the email and password were correct.</b>") }}
+  {{ render_text("An invalid " ~ (type | safe) ~ " code was provided <b>but the email and password were correct.</b>") }}
   {{ render_text("This request has been blocked. However, if this was <b>not</b> you, please <b>change your password immediately.</b>") }}
   {{ render_button("Change your password", URL ~ "/dashboard/setting#change_password") }}
   {{ render_text('Thanks,

--- a/templates/emails/transactional/reset_password_leak.html
+++ b/templates/emails/transactional/reset_password_leak.html
@@ -7,9 +7,9 @@
 	{{ render_text("For your security, we have <b>reset your password</b> and temporarily locked access until you set a new one. If you have a Proton account you can still access your account using <b>Login with Proton</b>.") }}
   {{ render_text("<b>What you need to do:</b>") }}
   {{ render_text("<ol>") }}
-  {{ render_text("<li>Go to <a href=\"" ~ (password_reset_link | safe) ~ "\">Forgot my password</a> to set a new password.</li>") }}
+  {{ render_text("<li>Go to <a href=\"" + (password_reset_link | safe) + "\">Forgot my password</a> to set a new password.</li>") }}
 	{{ render_text("<li>Choose a strong, unique password that you haven’t used anywhere else. You can use <a href=\"https://proton.me/pass\">Proton Pass</a> to generate a strong password and <b>store it safely.</b></li>") }}
-  {{ render_text("<li>Once your new password is set, we highly recommend <b>enabling Two-Factor Authentication (2FA)</b> in your <a href=\"" ~ (account_link | safe) ~ "\">account settings</a> for an extra layer of protection.</li>") }}
+  {{ render_text("<li>Once your new password is set, we highly recommend <b>enabling Two-Factor Authentication (2FA)</b> in your <a href=\"" + (account_link | safe) + "\">account settings</a> for an extra layer of protection.</li>") }}
   {{ render_text("</ol>") }}
   {{ render_text("Please note: there’s no indication that our systems have been breached. This action is a precautionary measure to help ensure your continued security.") }}
   {{ render_text("We understand that security alerts can be concerning, but this type of monitoring is one of the ways we keep your account safe. If you have any questions or need help resetting your password, our support team is available.") }}

--- a/templates/emails/transactional/reset_password_leak.html
+++ b/templates/emails/transactional/reset_password_leak.html
@@ -7,9 +7,9 @@
 	{{ render_text("For your security, we have <b>reset your password</b> and temporarily locked access until you set a new one. If you have a Proton account you can still access your account using <b>Login with Proton</b>.") }}
   {{ render_text("<b>What you need to do:</b>") }}
   {{ render_text("<ol>") }}
-  {{ render_text("<li>Go to <a href=\"" + password_reset_link + "\">Forgot my password</a> to set a new password.</li>") }}
+  {{ render_text("<li>Go to <a href=\"" ~ (password_reset_link | safe) ~ "\">Forgot my password</a> to set a new password.</li>") }}
 	{{ render_text("<li>Choose a strong, unique password that you haven’t used anywhere else. You can use <a href=\"https://proton.me/pass\">Proton Pass</a> to generate a strong password and <b>store it safely.</b></li>") }}
-  {{ render_text("<li>Once your new password is set, we highly recommend <b>enabling Two-Factor Authentication (2FA)</b> in your <a href=\"" + account_link +"\">account settings</a> for an extra layer of protection.</li>") }}
+  {{ render_text("<li>Once your new password is set, we highly recommend <b>enabling Two-Factor Authentication (2FA)</b> in your <a href=\"" ~ (account_link | safe) ~ "\">account settings</a> for an extra layer of protection.</li>") }}
   {{ render_text("</ol>") }}
   {{ render_text("Please note: there’s no indication that our systems have been breached. This action is a precautionary measure to help ensure your continued security.") }}
   {{ render_text("We understand that security alerts can be concerning, but this type of monitoring is one of the ways we keep your account safe. If you have any questions or need help resetting your password, our support team is available.") }}

--- a/templates/emails/transactional/send-from-alias-from-unknown-sender.html
+++ b/templates/emails/transactional/send-from-alias-from-unknown-sender.html
@@ -3,10 +3,10 @@
 {% block content %}
 
   {{ render_text("This is an automated email from SimpleLogin.") }}
-  {{ render_text("We have recorded an attempt to send an email from your email <b>" ~ (sender | safe) ~ "</b> to <b>" ~ (reply_email | safe) ~ "</b>.") }}
-  {{ render_text((reply_email | safe) ~ ' is a special email address that only receives emails from its authorized user.') }}
+  {{ render_text("We have recorded an attempt to send an email from your email <b>" + (sender | safe) + "</b> to <b>" + (reply_email | safe) + "</b>.") }}
+  {{ render_text((reply_email | safe) + ' is a special email address that only receives emails from its authorized user.') }}
   {{ render_text("This user has been also informed of this incident.") }}
-  {{ render_text('If you have any question, you can contact us by replying to this email or consult our website at ' ~ (LANDING_PAGE_URL | safe) ~ '.') }}
+  {{ render_text('If you have any question, you can contact us by replying to this email or consult our website at ' + (LANDING_PAGE_URL | safe) + '.') }}
   {{ render_text('Regards,
     <br />
     SimpleLogin Team.') }}

--- a/templates/emails/transactional/send-from-alias-from-unknown-sender.html
+++ b/templates/emails/transactional/send-from-alias-from-unknown-sender.html
@@ -3,10 +3,10 @@
 {% block content %}
 
   {{ render_text("This is an automated email from SimpleLogin.") }}
-  {{ render_text("We have recorded an attempt to send an email from your email <b>" + sender + "</b> to <b>" + reply_email + "</b>.") }}
-  {{ render_text(reply_email + ' is a special email address that only receives emails from its authorized user.') }}
+  {{ render_text("We have recorded an attempt to send an email from your email <b>" ~ (sender | safe) ~ "</b> to <b>" ~ (reply_email | safe) ~ "</b>.") }}
+  {{ render_text((reply_email | safe) ~ ' is a special email address that only receives emails from its authorized user.') }}
   {{ render_text("This user has been also informed of this incident.") }}
-  {{ render_text('If you have any question, you can contact us by replying to this email or consult our website at ' ~ LANDING_PAGE_URL ~ '.') }}
+  {{ render_text('If you have any question, you can contact us by replying to this email or consult our website at ' ~ (LANDING_PAGE_URL | safe) ~ '.') }}
   {{ render_text('Regards,
     <br />
     SimpleLogin Team.') }}

--- a/templates/emails/transactional/subscription-end.html
+++ b/templates/emails/transactional/subscription-end.html
@@ -3,7 +3,7 @@
 {% block content %}
 
   {{ render_text("Hi") }}
-  {{ render_text("Your subscription will end on " ~ (next_bill_date | safe) ~ ".") }}
+  {{ render_text("Your subscription will end on " + (next_bill_date | safe) + ".") }}
   {{ render_text("When the subscription ends:") }}
   {{ render_text("- All aliases/domains/directories you have created are <b>kept</b> and continue working normally.") }}
   {{ render_text("- You cannot create new reverse aliases.") }}
@@ -18,7 +18,7 @@
 
   {{ render_text("- You cannot add new domain or directory.") }}
   {{ render_text("You can upgrade today to continue using all these Premium features (and much more coming).") }}
-  {{ render_button("Upgrade your account", URL ~ "/dashboard/pricing") }}
+  {{ render_button("Upgrade your account", URL + "/dashboard/pricing") }}
   {{ render_text('Regardless of your choice, we want to say thank you for trying SimpleLogin. We know the product
     requires an investment of your time, and we appreciate you giving us a chance.') }}
   {{ render_text('Thanks,
@@ -27,5 +27,5 @@
   {{ render_text('P.S. If you have any questions or need any help, please don\'t hesitate to
     <a href="https://app.simplelogin.io/dashboard/support">reach out</a>
     ') }}
-  {{ raw_url(URL ~ "/dashboard/pricing") }}
+  {{ raw_url(URL + "/dashboard/pricing") }}
 {% endblock %}

--- a/templates/emails/transactional/subscription-end.html
+++ b/templates/emails/transactional/subscription-end.html
@@ -3,7 +3,7 @@
 {% block content %}
 
   {{ render_text("Hi") }}
-  {{ render_text("Your subscription will end on " + next_bill_date + ".") }}
+  {{ render_text("Your subscription will end on " ~ (next_bill_date | safe) ~ ".") }}
   {{ render_text("When the subscription ends:") }}
   {{ render_text("- All aliases/domains/directories you have created are <b>kept</b> and continue working normally.") }}
   {{ render_text("- You cannot create new reverse aliases.") }}

--- a/templates/emails/transactional/test-email.html
+++ b/templates/emails/transactional/test-email.html
@@ -2,6 +2,6 @@
 
 {% block content %}
 
-  {{ render_text("Hi " + name) }}
-  {{ render_text("This is a test to make sure that you receive emails sent to your alias <b>" + alias + "</b>.") }}
+  {{ render_text("Hi " ~ (name | safe)) }}
+  {{ render_text("This is a test to make sure that you receive emails sent to your alias <b>" ~ (alias | safe) ~ "</b>.") }}
 {% endblock %}

--- a/templates/emails/transactional/test-email.html
+++ b/templates/emails/transactional/test-email.html
@@ -2,6 +2,6 @@
 
 {% block content %}
 
-  {{ render_text("Hi " ~ (name | safe)) }}
-  {{ render_text("This is a test to make sure that you receive emails sent to your alias <b>" ~ (alias | safe) ~ "</b>.") }}
+  {{ render_text("Hi " + (name | safe)) }}
+  {{ render_text("This is a test to make sure that you receive emails sent to your alias <b>" + (alias | safe) + "</b>.") }}
 {% endblock %}

--- a/templates/emails/transactional/trial-end.html
+++ b/templates/emails/transactional/trial-end.html
@@ -17,10 +17,10 @@
   {{ render_text("- You cannot create new reverse aliases.") }}
   {{ render_text("- If you enable PGP Encryption, forwarded emails are not encrypted anymore.") }}
   {{ render_text("You can upgrade today to continue using all these Premium features (and much more coming).") }}
-  {{ render_button("Upgrade your account", URL ~ "/dashboard/pricing") }}
+  {{ render_button("Upgrade your account", URL + "/dashboard/pricing") }}
   {{ render_text("If you're not ready to upgrade to a paying account, you have a few other options available to you:") }}
   {{ grey_section([
-    "<b>Continue with the Free Plan</b> - In the free plan you are limited to " ~ MAX_NB_EMAIL_FREE_PLAN ~ " aliases but there's no cap on bandwidth or
+    "<b>Continue with the Free Plan</b> - In the free plan you are limited to " + MAX_NB_EMAIL_FREE_PLAN + " aliases but there's no cap on bandwidth or
     number of emails forwarded/sent.",
     "<b>Share feedback</b> - If SimpleLogin isn't right for you, let us know what you were looking for and we might be able to suggest some alternatives that might be a better fit.",
     "<b>Export your data</b> - If SimpleLogin wasn't a good fit, you can export your data for use elsewhere. ",
@@ -34,5 +34,5 @@
   {{ render_text('P.S. If you have any questions or need any help, please don\'t hesitate to
     <a href="https://app.simplelogin.io/dashboard/support">reach out</a>
     ') }}
-  {{ raw_url(URL ~ "/dashboard/pricing") }}
+  {{ raw_url(URL + "/dashboard/pricing") }}
 {% endblock %}

--- a/templates/emails/transactional/verify-mailbox-change.html
+++ b/templates/emails/transactional/verify-mailbox-change.html
@@ -3,7 +3,7 @@
 {% block content %}
 
   {{ render_text("Hi") }}
-  {{ render_text("You recently requested to change mailbox <b>"+ mailbox_email +"</b> to <b>" + mailbox_new_email + "</b>.") }}
+  {{ render_text("You recently requested to change mailbox <b>"~ (mailbox_email | safe) ~"</b> to <b>" ~ (mailbox_new_email | safe) ~ "</b>.") }}
   {{ render_text("To confirm, please click on the button below.") }}
   {{ render_button("Confirm mailbox change", link) }}
   {{ render_text("This email will only be valid for the next 15 minutes.") }}

--- a/templates/emails/transactional/verify-mailbox-change.html
+++ b/templates/emails/transactional/verify-mailbox-change.html
@@ -3,7 +3,7 @@
 {% block content %}
 
   {{ render_text("Hi") }}
-  {{ render_text("You recently requested to change mailbox <b>"~ (mailbox_email | safe) ~"</b> to <b>" ~ (mailbox_new_email | safe) ~ "</b>.") }}
+  {{ render_text("You recently requested to change mailbox <b>"~ (mailbox_email | safe) ~"</b> to <b>" + (mailbox_new_email | safe) + "</b>.") }}
   {{ render_text("To confirm, please click on the button below.") }}
   {{ render_button("Confirm mailbox change", link) }}
   {{ render_text("This email will only be valid for the next 15 minutes.") }}

--- a/templates/emails/transactional/verify-mailbox.html
+++ b/templates/emails/transactional/verify-mailbox.html
@@ -3,13 +3,13 @@
 {% block content %}
 
   {{ render_text("Hi") }}
-  {{ render_text("You have added <b>"+ mailbox_email +"</b> as an additional mailbox.") }}
+  {{ render_text("You have added <b>" ~ (mailbox_email | safe) ~ "</b> as an additional mailbox.") }}
   {% if link %}
 
     {{ render_text("To confirm, please click on the button below.") }}
     {{ render_button("Confirm mailbox", link) }}
   {% else %}
-    {{ render_text("Please enter <b>"+code+"</b> as your verification code") }}
+    {{ render_text("Please enter <b>" ~ (code | safe) ~ "</b> as your verification code") }}
   {% endif %}
   {{ render_text("This email will only be valid for the next 15 minutes.") }}
   {{ render_text('Thanks,

--- a/templates/emails/transactional/verify-mailbox.html
+++ b/templates/emails/transactional/verify-mailbox.html
@@ -3,13 +3,13 @@
 {% block content %}
 
   {{ render_text("Hi") }}
-  {{ render_text("You have added <b>" ~ (mailbox_email | safe) ~ "</b> as an additional mailbox.") }}
+  {{ render_text("You have added <b>" + (mailbox_email | safe) + "</b> as an additional mailbox.") }}
   {% if link %}
 
     {{ render_text("To confirm, please click on the button below.") }}
     {{ render_button("Confirm mailbox", link) }}
   {% else %}
-    {{ render_text("Please enter <b>" ~ (code | safe) ~ "</b> as your verification code") }}
+    {{ render_text("Please enter <b>" + (code | safe) + "</b> as your verification code") }}
   {% endif %}
   {{ render_text("This email will only be valid for the next 15 minutes.") }}
   {{ render_text('Thanks,


### PR DESCRIPTION
Currently emails autoescape tags and they render in the emails due to having `autoescape=select_autoescape(["html"]`. To render correctly the emails this MR removes the autoescape and escapes each var individually.