### PR TITLE
Fix: Unauthenticated Apple webhook + monitor endpoint information disclosure

### DIFF
--- a/app/api/views/apple.py
+++ b/app/api/views/apple.py
@@ -63,6 +63,7 @@ def apple_process_payment():
 
 
 @api_bp.route("/apple/update_notification", methods=["POST"])
+@require_api_auth
 def apple_update_notification():
     """
     The "Subscription Status URL" to receive update notifications from Apple
@@ -239,7 +240,7 @@ def apple_update_notification():
     # }
     LOG.d("request for /api/apple/update_notification")
     data = request.get_json()
-    if config.APPLE_WEBHOOK_SECRET_CHECK_ENABLED and (
+    if (
         not data
         or not data.get("password")
         or data.get("password")

--- a/app/config.py
+++ b/app/config.py
@@ -364,7 +364,7 @@ APPLE_API_SECRET = os.environ.get("APPLE_API_SECRET")
 # for Mac App
 MACAPP_APPLE_API_SECRET = os.environ.get("MACAPP_APPLE_API_SECRET")
 # When enabled, /apple/update_notification validates the shared secret in the webhook payload
-APPLE_WEBHOOK_SECRET_CHECK_ENABLED = "APPLE_WEBHOOK_SECRET_CHECK_ENABLED" in os.environ
+APPLE_WEBHOOK_SECRET_CHECK_ENABLED = True  # Always enabled for security
 
 # <<<<< ALERT EMAIL >>>>
 

--- a/app/monitor/views.py
+++ b/app/monitor/views.py
@@ -1,13 +1,17 @@
+from flask_login import login_required
+
 from app.build_info import SHA1, VERSION
 from app.monitor.base import monitor_bp
 
 
 @monitor_bp.route("/git")
+@login_required
 def git_sha1():
     return SHA1
 
 
 @monitor_bp.route("/version")
+@login_required
 def version():
     return VERSION
 
@@ -18,6 +22,7 @@ def live():
 
 
 @monitor_bp.route("/exception")
+@login_required
 def test_exception():
     raise Exception("to make sure sentry works")
     return "never reach here"


### PR DESCRIPTION
## Summary

This PR fixes two security vulnerabilities:

### 1. CWE-306: Unauthenticated Apple Webhook Subscription Manipulation (CRITICAL, CVSS 8.6)

- **File:** `app/api/views/apple.py`
- **Issue:** The `/api/apple/update_notification` route had no `@require_api_auth` decorator, allowing unauthenticated attackers to manipulate Apple subscription webhooks.
- **Fix:**
  - Added `@require_api_auth` decorator to `apple_update_notification()` to enforce API key authentication.
  - Removed the `config.APPLE_WEBHOOK_SECRET_CHECK_ENABLED` conditional so the webhook secret (password) validation is always enforced in the function body.
  - Changed `APPLE_WEBHOOK_SECRET_CHECK_ENABLED` in `config.py` to default to `True` for defense-in-depth.

### 2. CWE-200: Info Disclosure via Monitor Endpoints (MEDIUM, CVSS 5.3)

- **File:** `app/monitor/views.py`
- **Issue:** Four unauthenticated endpoints (`/git`, `/version`, `/live`, `/exception`) exposed sensitive information including the git SHA, version details, and an exception trigger for Sentry testing.
- **Fix:**
  - Added `@login_required` protection to `/git`, `/version`, and `/exception` endpoints.
  - Kept `/live` open for health checks (returns only "live", no sensitive data).

## Test Plan

- [ ] Verify `/api/apple/update_notification` requires valid API key authentication
- [ ] Verify webhook password validation is always enforced regardless of config
- [ ] Verify `/git`, `/version`, `/exception` return 401/redirect when unauthenticated
- [ ] Verify `/live` still responds for health check monitoring


