### PR TITLE
Fix tx deadlock

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2340,6 +2340,16 @@ class EmailLog(Base, ModelMixin):
         commit = kwargs.pop("commit", False)
         if "message_id" in kwargs and kwargs["message_id"]:
             kwargs["message_id"] = kwargs["message_id"][:250]
+        if "alias_id" in kwargs:
+            # Acquire an exclusive lock on the alias row before inserting so that
+            # concurrent inserts for the same alias always acquire locks in the same
+            # order (alias first, then email_log), preventing the deadlock that occurs
+            # when two transactions each hold a share lock on the alias FK and then
+            # both try to escalate to an exclusive lock for the UPDATE below.
+            Session.execute(
+                "SELECT id FROM alias WHERE id = :alias_id FOR UPDATE",
+                {"alias_id": kwargs["alias_id"]},
+            )
         email_log = super().create(*args, **kwargs)
         Session.flush()
         if "alias_id" in kwargs:

--- a/app/models.py
+++ b/app/models.py
@@ -1773,6 +1773,21 @@ class Alias(Base, ModelMixin):
                 return custom_domain
 
     @classmethod
+    def lock_for_update(cls, alias_id: int):
+        """Acquire an exclusive row lock on the alias to serialise concurrent writes.
+
+        Call this before creating an EmailLog for the alias so that the lock order
+        is always alias → email_log, preventing the deadlock that arises when two
+        concurrent transactions each hold a share lock (from the email_log FK insert)
+        and then both try to escalate to an exclusive lock for the
+        last_email_log_id UPDATE.
+        """
+        Session.execute(
+            "SELECT id FROM alias WHERE id = :alias_id FOR UPDATE",
+            {"alias_id": alias_id},
+        )
+
+    @classmethod
     def create(cls, **kw):
         commit = kw.pop("commit", False)
         flush = kw.pop("flush", False)
@@ -2340,16 +2355,6 @@ class EmailLog(Base, ModelMixin):
         commit = kwargs.pop("commit", False)
         if "message_id" in kwargs and kwargs["message_id"]:
             kwargs["message_id"] = kwargs["message_id"][:250]
-        if "alias_id" in kwargs:
-            # Acquire an exclusive lock on the alias row before inserting so that
-            # concurrent inserts for the same alias always acquire locks in the same
-            # order (alias first, then email_log), preventing the deadlock that occurs
-            # when two transactions each hold a share lock on the alias FK and then
-            # both try to escalate to an exclusive lock for the UPDATE below.
-            Session.execute(
-                "SELECT id FROM alias WHERE id = :alias_id FOR UPDATE",
-                {"alias_id": kwargs["alias_id"]},
-            )
         email_log = super().create(*args, **kwargs)
         Session.flush()
         if "alias_id" in kwargs:

--- a/email_handler.py
+++ b/email_handler.py
@@ -625,6 +625,7 @@ def handle_forward(envelope, msg: Message, rcpt_to: str) -> List[Tuple[bool, str
 
     if alias.user.delete_on is not None:
         LOG.d(f"user {user} is pending to be deleted. Do not forward")
+        Alias.lock_for_update(contact.alias_id)
         EmailLog.create(
             contact_id=contact.id,
             user_id=contact.user_id,
@@ -644,6 +645,7 @@ def handle_forward(envelope, msg: Message, rcpt_to: str) -> List[Tuple[bool, str
         if contact.block_forward:
             LOG.d("Contact %s of alias %s is blocked, do not forward", contact, alias)
 
+        Alias.lock_for_update(contact.alias_id)
         EmailLog.create(
             contact_id=contact.id,
             user_id=contact.user_id,
@@ -784,6 +786,7 @@ def forward_email_to_mailbox(
         # so when user fixes the mailbox, the email can be delivered
         return False, status.E405
 
+    Alias.lock_for_update(contact.alias_id)
     email_log = EmailLog.create(
         contact_id=contact.id,
         user_id=contact.user_id,
@@ -1125,6 +1128,7 @@ def handle_reply(
             # cannot use 5** because that generates bounce report
             return True, status.E201
 
+    Alias.lock_for_update(contact.alias_id)
     email_log = EmailLog.create(
         contact_id=contact.id,
         alias_id=contact.alias_id,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,6 +12,7 @@ from app.models import (
     generate_random_alias_email,
     Alias,
     Contact,
+    EmailLog,
     Mailbox,
     SenderFormatEnum,
     EnumE,
@@ -388,3 +389,40 @@ def test_sync_event_dead_letter():
     assert e3 not in dead_letter_events
     assert e4 not in dead_letter_events
     assert e5 not in dead_letter_events
+
+
+def test_email_log_create_updates_alias_last_email_log_id(flask_client):
+    user = create_new_user()
+    alias = Alias.create_new_random(user)
+    mailbox = Mailbox.get(alias.mailbox_id)
+    contact = Contact.create(
+        user_id=user.id,
+        alias_id=alias.id,
+        website_email=f"{random_token()}@example.com",
+        reply_email=f"reply-{random_token()}@sl.local",
+        commit=True,
+    )
+
+    el1 = EmailLog.create(
+        contact_id=contact.id,
+        user_id=user.id,
+        mailbox_id=mailbox.id,
+        alias_id=alias.id,
+        message_id="msg1@test",
+        commit=True,
+    )
+
+    Session.expire(alias)
+    assert alias.last_email_log_id == el1.id
+
+    el2 = EmailLog.create(
+        contact_id=contact.id,
+        user_id=user.id,
+        mailbox_id=mailbox.id,
+        alias_id=alias.id,
+        message_id="msg2@test",
+        commit=True,
+    )
+
+    Session.expire(alias)
+    assert alias.last_email_log_id == el2.id


### PR DESCRIPTION
Fix TX deadlock:
 - First query is `INSERT email_log...`
 - Second query is `UPDATE alias ..`
 First query locks the alias because of an FK and prevents another tx from finishing.

```  
TX A - insert email_log -> row lock on email_log table -> alias row lock via FK
TX B - insert email_log -> row lock on email_log table -> alias row lock via FK
TX A - update alias -> wait on lock on alias row
TX B - update alias -> wait on lock on alias row
DEADLOCK
```

To prevent it we get the alias for update before on EmailLog creation