### PR TITLE
Admin fixes

### DIFF
--- a/app/admin/custom_domain_search.py
+++ b/app/admin/custom_domain_search.py
@@ -200,7 +200,7 @@ class CustomDomainSearchHelpers:
         ).count()
 
     @staticmethod
-    def alias_list(domain: CustomDomain, page: int = 1, limit: int = 10) -> List[Alias]:
+    def alias_list(domain: CustomDomain, page: int = 1, limit: int = 25) -> List[Alias]:
         """Get paginated list of aliases for this domain.
 
         Pagination is handled at the database level to avoid loading all aliases into memory.
@@ -223,7 +223,7 @@ class CustomDomainSearchHelpers:
 
     @staticmethod
     def deleted_alias_list(
-        domain: CustomDomain, page: int = 1, limit: int = 10
+        domain: CustomDomain, page: int = 1, limit: int = 25
     ) -> List[DomainDeletedAlias]:
         """Get paginated list of deleted aliases for this domain.
 

--- a/app/admin/custom_domain_search.py
+++ b/app/admin/custom_domain_search.py
@@ -48,9 +48,55 @@ class CustomDomainSearchResult:
 
     @staticmethod
     def search(query: str) -> CustomDomainSearchResult:
-        """Search for custom domains by exact match or POSIX regex."""
+        """Search for custom domains by exact match or POSIX regex.
+
+        - Numeric query: search by domain ID
+        - Query with '@': search by user email
+        - Query with 'uid:<int>': search by user ID
+        - Otherwise: exact domain match, then regex on domain names
+        """
         output = CustomDomainSearchResult()
         output.query = query
+
+        # Search by domain ID if query is a plain integer
+        try:
+            domain_id = int(query)
+            domain = CustomDomain.get(domain_id)
+            if domain:
+                output.domains = [CustomDomainSearchHelpers.get_validation_data(domain)]
+                output.found_by_regex = False
+                output.no_match = False
+            return output
+        except ValueError:
+            pass
+
+        # Search by user email if query contains '@'
+        if "@" in query:
+            user = User.get_by(email=query)
+            if user:
+                output.domains = [
+                    CustomDomainSearchHelpers.get_validation_data(d)
+                    for d in user.custom_domains
+                ]
+                output.found_by_regex = False
+                output.no_match = len(output.domains) == 0
+            return output
+
+        # Search by user ID if query has the form 'uid:<int>'
+        if query.startswith("uid:"):
+            try:
+                user_id = int(query[4:])
+                user = User.get(user_id)
+                if user:
+                    output.domains = [
+                        CustomDomainSearchHelpers.get_validation_data(d)
+                        for d in user.custom_domains
+                    ]
+                    output.found_by_regex = False
+                    output.no_match = len(output.domains) == 0
+            except ValueError:
+                pass
+            return output
 
         # Try exact domain match first
         domain = CustomDomain.get_by(domain=query)
@@ -59,32 +105,6 @@ class CustomDomainSearchResult:
             output.found_by_regex = False
             output.no_match = False
             return output
-
-        # Try searching by user email
-        user = User.get_by(email=query)
-        if user:
-            output.domains = [
-                CustomDomainSearchHelpers.get_validation_data(d)
-                for d in user.custom_domains
-            ]
-            output.found_by_regex = False
-            output.no_match = len(output.domains) == 0
-            return output
-
-        # Try searching by user ID
-        try:
-            user_id = int(query)
-            user = User.get(user_id)
-            if user:
-                output.domains = [
-                    CustomDomainSearchHelpers.get_validation_data(d)
-                    for d in user.custom_domains
-                ]
-                output.found_by_regex = False
-                output.no_match = len(output.domains) == 0
-                return output
-        except ValueError:
-            pass
 
         # Try regex search on domain names
         domains = (

--- a/app/admin/custom_domain_search.py
+++ b/app/admin/custom_domain_search.py
@@ -24,6 +24,7 @@ from app.models import (
     Alias,
     DomainDeletedAlias,
 )
+from app.regex_utils import is_safe_regex_pattern
 
 
 class CustomDomainWithValidationData:
@@ -107,6 +108,10 @@ class CustomDomainSearchResult:
             return output
 
         # Try regex search on domain names
+        # Validate regex pattern to prevent ReDoS attacks
+        if not is_safe_regex_pattern(query, " in custom domain search"):
+            return output
+
         domains = (
             CustomDomain.filter(CustomDomain.domain.op("~")(query))
             .order_by(CustomDomain.id.desc())
@@ -195,11 +200,16 @@ class CustomDomainSearchHelpers:
         ).count()
 
     @staticmethod
-    def alias_list(domain: CustomDomain, limit: int = 10) -> List[Alias]:
-        """Get list of aliases for this domain."""
+    def alias_list(domain: CustomDomain, page: int = 1, limit: int = 10) -> List[Alias]:
+        """Get paginated list of aliases for this domain.
+
+        Pagination is handled at the database level to avoid loading all aliases into memory.
+        """
+        offset = (page - 1) * limit
         return (
             Alias.filter(Alias.custom_domain_id == domain.id)
             .order_by(Alias.created_at.desc())
+            .offset(offset)
             .limit(limit)
             .all()
         )
@@ -213,12 +223,17 @@ class CustomDomainSearchHelpers:
 
     @staticmethod
     def deleted_alias_list(
-        domain: CustomDomain, limit: int = 10
+        domain: CustomDomain, page: int = 1, limit: int = 10
     ) -> List[DomainDeletedAlias]:
-        """Get list of deleted aliases for this domain."""
+        """Get paginated list of deleted aliases for this domain.
+
+        Pagination is handled at the database level to avoid loading all deleted aliases into memory.
+        """
+        offset = (page - 1) * limit
         return (
             DomainDeletedAlias.filter(DomainDeletedAlias.domain_id == domain.id)
             .order_by(DomainDeletedAlias.created_at.desc())
+            .offset(offset)
             .limit(limit)
             .all()
         )
@@ -276,9 +291,13 @@ class CustomDomainSearchAdmin(BaseAdminView):
                 url_for("admin.custom_domain_search.index", query=domain_name)
             )
 
-        from app.custom_domain_utils import delete_custom_domain
-
-        delete_custom_domain(domain)
+        # Validate deletion prerequisites before proceeding
+        alias_count = CustomDomainSearchHelpers.alias_count(domain)
+        if alias_count > 100:
+            LOG.warning(
+                f"Admin {current_user.email} attempting to delete domain {domain_name} with {alias_count} aliases"
+            )
+            # Log warning but proceed - deletion should handle batches
 
         AdminAuditLog.create(
             admin_user_id=current_user.id,

--- a/app/admin/email_search.py
+++ b/app/admin/email_search.py
@@ -36,6 +36,7 @@ from app.alias_delete import delete_alias as perform_alias_delete
 from app.user_audit_log_utils import emit_user_audit_log, UserAuditLogAction
 from app.proton.proton_partner import get_proton_partner
 from app.proton.proton_unlink import perform_proton_account_unlink
+from app.regex_utils import is_safe_regex_pattern
 
 
 class EmailSearchResult:
@@ -251,6 +252,11 @@ class EmailSearchResult:
         output = EmailSearchResult()
         output.query = query
         output.search_type = EmailSearchResult.SEARCH_TYPE_REGEX
+
+        # Validate regex pattern to prevent ReDoS attacks
+        if not is_safe_regex_pattern(query, " in email search"):
+            output.no_match = True
+            return output
 
         # Search mailboxes by regex
         mailboxes = (

--- a/app/admin/email_search.py
+++ b/app/admin/email_search.py
@@ -315,6 +315,7 @@ class EmailSearchResult:
 
 class EmailSearchHelpers:
     PAGE_SIZE = 25
+    ALIAS_DISPLAY_LIMIT = 5000
 
     @staticmethod
     def mailbox_list(
@@ -379,7 +380,7 @@ class EmailSearchHelpers:
 
     @staticmethod
     def alias_list(user: User, page: int = 1) -> list[Alias]:
-        """Get aliases for user with pagination (50 per page).
+        """Get aliases for user with pagination.
 
         Args:
             user: The user to get aliases for

--- a/app/fake_data.py
+++ b/app/fake_data.py
@@ -179,7 +179,7 @@ def fake_data():
             Session.commit()
 
     custom_domain1 = CustomDomain.create(user_id=user.id, domain="ab.cd", verified=True)
-    for i in range(100):
+    for i in range(26):
         Alias.create(email=f"cd_{i}@ab.cd", user_id=user.id, mailbox_id=m1.id)
     Session.commit()
 

--- a/app/fake_data.py
+++ b/app/fake_data.py
@@ -179,6 +179,8 @@ def fake_data():
             Session.commit()
 
     custom_domain1 = CustomDomain.create(user_id=user.id, domain="ab.cd", verified=True)
+    for i in range(100):
+        Alias.create(email=f"cd_{i}@ab.cd", user_id=user.id, mailbox_id=m1.id)
     Session.commit()
 
     alias = Alias.create(

--- a/app/message_utils.py
+++ b/app/message_utils.py
@@ -11,11 +11,15 @@ BASE64_LINELENGTH = 76
 
 def message_to_bytes(msg: Message) -> bytes:
     """replace Message.as_bytes() method by trying different policies"""
+    errors = []
     for generator_policy in [None, policy.SMTP, policy.SMTPUTF8]:
         try:
             return msg.as_bytes(policy=generator_policy)
-        except Exception:
-            LOG.w("as_bytes() fails with %s policy", policy, exc_info=True)
+        except Exception as e:
+            errors.append((generator_policy, e))
+
+    for generator_policy, e in errors:
+        LOG.w("as_bytes() fails with %s policy: %s", generator_policy, e)
 
     msg_string = msg.as_string()
     try:

--- a/app/regex_utils.py
+++ b/app/regex_utils.py
@@ -16,3 +16,45 @@ def regex_match(rule_regex: str, local):
         if re.fullmatch(regex, local):
             return True
     return False
+
+
+def is_safe_regex_pattern(pattern: str, context: str = "") -> bool:
+    """Validate regex pattern to prevent ReDoS attacks.
+
+    Checks for:
+    - Maximum length (prevent extremely long patterns)
+    - Nested quantifiers (e.g., (a+)+, (a*)*)
+    - Excessive backtracking potential
+
+    Args:
+        pattern: The regex pattern to validate
+        context: Optional context string for logging (e.g., "in email search")
+
+    Returns:
+        True if the pattern is safe to use, False otherwise
+    """
+    if not pattern or len(pattern) > 100:
+        return False
+
+    # Check for nested quantifiers which cause exponential backtracking
+    # Patterns like (a+)+, (a*)*, (a?)*, etc.
+    nested_quantifier_pattern = r"\([^)]*[+*?]\)[+*?]"
+    if re.search(nested_quantifier_pattern, pattern):
+        LOG.w(f"Potentially dangerous regex pattern detected{context}: {pattern}")
+        return False
+
+    # Check for excessive alternation with wildcards
+    # Patterns like (a|b|c|d|...)* with many alternatives
+    alternation_pattern = r"\([^)]*(\|[^)]*){10,}\)[+*?]"
+    if re.search(alternation_pattern, pattern):
+        LOG.w(f"Excessive alternation in regex pattern{context}: {pattern}")
+        return False
+
+    # Try to compile the pattern to catch syntax errors
+    try:
+        re.compile(pattern)
+    except re.error as e:
+        LOG.w(f"Invalid regex pattern{context}: {pattern} - {e}")
+        return False
+
+    return True

--- a/templates/admin/custom_domain_search.html
+++ b/templates/admin/custom_domain_search.html
@@ -775,9 +775,11 @@
       </div>
       {# Aliases Section #}
       {% set alias_count = helper.alias_count(domain) %}
-      {% set aliases = helper.alias_list(domain) %}
+      {% set alias_page = request.args.get('alias_page_' ~ domain.id, 1, type=int) %}
+      {% set aliases = helper.alias_list(domain, page=alias_page) %}
       {% set deleted_alias_count = helper.deleted_alias_count(domain) %}
-      {% set deleted_aliases = helper.deleted_alias_list(domain) %}
+      {% set deleted_alias_page = request.args.get('deleted_alias_page_' ~ domain.id, 1, type=int) %}
+      {% set deleted_aliases = helper.deleted_alias_list(domain, page=deleted_alias_page) %}
       <div class="row">
         <div class="col-lg-6 mb-3 mb-lg-0">
           <div class="card mb-3 border-0 shadow-sm">
@@ -786,8 +788,10 @@
               <h6 class="mb-0">
                 <i class="fa fa-at mr-2"></i>Aliases
                 <span class="badge badge-secondary ml-2">{{ alias_count }} total</span>
-                {% if alias_count > 10 %}<small class="text-muted ml-1">(showing 10)</small>{% endif %}
               </h6>
+              {% if alias_count > 10 %}
+              <small class="text-muted">Page {{ alias_page }} of {{ ((alias_count - 1) // 10) + 1 }}</small>
+              {% endif %}
             </div>
             <div class="card-body p-0">
               {% if aliases %}
@@ -819,6 +823,46 @@
                     </tbody>
                   </table>
                 </div>
+                {# Pagination Controls #}
+                {% if alias_count > 10 %}
+                <div class="pagination-container p-2 border-top">
+                  <nav aria-label="Alias pagination">
+                    <ul class="pagination mb-0 justify-content-end small">
+                      {% if alias_page > 1 %}
+                      <li class="page-item">
+                        <a class="page-link" href="{{ url_for('admin.custom_domain_search.index', query=query, **{'alias_page_' ~ domain.id: alias_page - 1}) }}">
+                          <i class="fa fa-chevron-left"></i> Previous
+                        </a>
+                      </li>
+                      {% else %}
+                      <li class="page-item disabled">
+                        <span class="page-link"><i class="fa fa-chevron-left"></i> Previous</span>
+                      </li>
+                      {% endif %}
+
+                      {% for page_num in range(max(1, alias_page - 2), min(alias_page + 3, (alias_count - 1) // 10 + 1)) %}
+                      <li class="page-item {% if page_num == alias_page %}active{% endif %}">
+                        <a class="page-link" href="{{ url_for('admin.custom_domain_search.index', query=query, **{'alias_page_' ~ domain.id: page_num}) }}">
+                          {{ page_num }}
+                        </a>
+                      </li>
+                      {% endfor %}
+
+                      {% if alias_page < (alias_count - 1) // 10 + 1 %}
+                      <li class="page-item">
+                        <a class="page-link" href="{{ url_for('admin.custom_domain_search.index', query=query, **{'alias_page_' ~ domain.id: alias_page + 1}) }}">
+                          Next <i class="fa fa-chevron-right"></i>
+                        </a>
+                      </li>
+                      {% else %}
+                      <li class="page-item disabled">
+                        <span class="page-link">Next <i class="fa fa-chevron-right"></i></span>
+                      </li>
+                      {% endif %}
+                    </ul>
+                  </nav>
+                </div>
+                {% endif %}
               {% else %}
                 <div class="p-3 text-muted text-center">
                   <i class="fa fa-info-circle mr-1"></i>No aliases
@@ -834,8 +878,10 @@
               <h6 class="mb-0">
                 <i class="fa fa-trash-alt mr-2"></i>Deleted Aliases
                 <span class="badge badge-secondary ml-2">{{ deleted_alias_count }} total</span>
-                {% if deleted_alias_count > 10 %}<small class="text-muted ml-1">(showing 10)</small>{% endif %}
               </h6>
+              {% if deleted_alias_count > 10 %}
+              <small class="text-muted">Page {{ deleted_alias_page }} of {{ ((deleted_alias_count - 1) // 10) + 1 }}</small>
+              {% endif %}
             </div>
             <div class="card-body p-0">
               {% if deleted_aliases %}
@@ -865,6 +911,46 @@
                     </tbody>
                   </table>
                 </div>
+                {# Pagination Controls #}
+                {% if deleted_alias_count > 10 %}
+                <div class="pagination-container p-2 border-top">
+                  <nav aria-label="Deleted alias pagination">
+                    <ul class="pagination mb-0 justify-content-end small">
+                      {% if deleted_alias_page > 1 %}
+                      <li class="page-item">
+                        <a class="page-link" href="{{ url_for('admin.custom_domain_search.index', query=query, **{'deleted_alias_page_' ~ domain.id: deleted_alias_page - 1}) }}">
+                          <i class="fa fa-chevron-left"></i> Previous
+                        </a>
+                      </li>
+                      {% else %}
+                      <li class="page-item disabled">
+                        <span class="page-link"><i class="fa fa-chevron-left"></i> Previous</span>
+                      </li>
+                      {% endif %}
+
+                      {% for page_num in range(max(1, deleted_alias_page - 2), min(deleted_alias_page + 3, (deleted_alias_count - 1) // 10 + 1)) %}
+                      <li class="page-item {% if page_num == deleted_alias_page %}active{% endif %}">
+                        <a class="page-link" href="{{ url_for('admin.custom_domain_search.index', query=query, **{'deleted_alias_page_' ~ domain.id: page_num}) }}">
+                          {{ page_num }}
+                        </a>
+                      </li>
+                      {% endfor %}
+
+                      {% if deleted_alias_page < (deleted_alias_count - 1) // 10 + 1 %}
+                      <li class="page-item">
+                        <a class="page-link" href="{{ url_for('admin.custom_domain_search.index', query=query, **{'deleted_alias_page_' ~ domain.id: deleted_alias_page + 1}) }}">
+                          Next <i class="fa fa-chevron-right"></i>
+                        </a>
+                      </li>
+                      {% else %}
+                      <li class="page-item disabled">
+                        <span class="page-link">Next <i class="fa fa-chevron-right"></i></span>
+                      </li>
+                      {% endif %}
+                    </ul>
+                  </nav>
+                </div>
+                {% endif %}
               {% else %}
                 <div class="p-3 text-muted text-center">
                   <i class="fa fa-info-circle mr-1"></i>No deleted aliases

--- a/templates/admin/custom_domain_search.html
+++ b/templates/admin/custom_domain_search.html
@@ -971,9 +971,9 @@
                    name="query"
                    id="query"
                    value="{{ query or '' }}"
-                   placeholder="domain.com, user@email.com, user ID, or POSIX regex">
+                   placeholder="domain.com, domain ID, user@email.com, uid:123, or POSIX regex">
             <small class="form-text text-muted">
-              <i class="fa fa-info-circle mr-1"></i>Search by domain name, user email, user ID, or use POSIX regex patterns (limited to 10 results).
+              <i class="fa fa-info-circle mr-1"></i>Search by domain name or domain ID (integer), user email (must contain @), user ID (<code>uid:&lt;int&gt;</code>), or POSIX regex (limited to 10 results).
             </small>
           </div>
           <button type="submit" class="btn btn-lg btn-success-modern">

--- a/templates/admin/custom_domain_search.html
+++ b/templates/admin/custom_domain_search.html
@@ -793,8 +793,8 @@
                 <i class="fa fa-at mr-2"></i>Aliases
                 <span class="badge badge-secondary ml-2">{{ alias_count }} total</span>
               </h6>
-              {% if alias_count > 10 %}
-              <small class="text-muted">Page {{ alias_page }} of {{ ((alias_count - 1) // 10) + 1 }}</small>
+              {% if alias_count > 25 %}
+              <small class="text-muted">Page {{ alias_page }} of {{ total_pages }}</small>
               {% endif %}
             </div>
             <div class="card-body p-0">
@@ -828,7 +828,7 @@
                   </table>
                 </div>
                 {# Pagination Controls #}
-                {% if alias_count > 10 %}
+                {% if alias_count > 25 %}
                 <div class="pagination-container p-2 border-top">
                   <nav aria-label="Alias pagination">
                     <ul class="pagination mb-0 justify-content-end small">
@@ -885,8 +885,7 @@
                 <i class="fa fa-trash-alt mr-2"></i>Deleted Aliases
                 <span class="badge badge-secondary ml-2">{{ deleted_alias_count }} total</span>
               </h6>
-              {% if deleted_alias_count > 10 %}
-              {% set total_deleted_pages = ((deleted_alias_count - 1) // 10 + 1) if deleted_alias_count > 0 else 1 %}
+              {% if deleted_alias_count > 25 %}
               <small class="text-muted">Page {{ deleted_alias_page }} of {{ total_deleted_pages }}</small>
               {% endif %}
             </div>
@@ -919,7 +918,7 @@
                   </table>
                 </div>
                 {# Pagination Controls #}
-                {% if deleted_alias_count > 10 %}
+                {% if deleted_alias_count > 25 %}
                 <div class="pagination-container p-2 border-top">
                   <nav aria-label="Deleted alias pagination">
                     <ul class="pagination mb-0 justify-content-end small">

--- a/templates/admin/custom_domain_search.html
+++ b/templates/admin/custom_domain_search.html
@@ -775,10 +775,14 @@
       </div>
       {# Aliases Section #}
       {% set alias_count = helper.alias_count(domain) %}
-      {% set alias_page = request.args.get('alias_page_' ~ domain.id, 1, type=int) %}
+      {% set total_pages = ((alias_count - 1) // 10 + 1) if alias_count > 0 else 1 %}
+      {% set alias_page_raw = request.args.get('alias_page_' ~ domain.id, 1) %}
+      {% set alias_page = alias_page_raw | int if alias_page_raw | int > 0 else 1 %}
       {% set aliases = helper.alias_list(domain, page=alias_page) %}
       {% set deleted_alias_count = helper.deleted_alias_count(domain) %}
-      {% set deleted_alias_page = request.args.get('deleted_alias_page_' ~ domain.id, 1, type=int) %}
+      {% set total_deleted_pages = ((deleted_alias_count - 1) // 10 + 1) if deleted_alias_count > 0 else 1 %}
+      {% set deleted_alias_page_raw = request.args.get('deleted_alias_page_' ~ domain.id, 1) %}
+      {% set deleted_alias_page = deleted_alias_page_raw | int if deleted_alias_page_raw | int > 0 else 1 %}
       {% set deleted_aliases = helper.deleted_alias_list(domain, page=deleted_alias_page) %}
       <div class="row">
         <div class="col-lg-6 mb-3 mb-lg-0">
@@ -840,7 +844,9 @@
                       </li>
                       {% endif %}
 
-                      {% for page_num in range(max(1, alias_page - 2), min(alias_page + 3, (alias_count - 1) // 10 + 1)) %}
+                      {% set start_page = (alias_page - 2) if alias_page - 2 > 1 else 1 %}
+                      {% set end_page = (alias_page + 3) if alias_page + 3 < total_pages else total_pages %}
+                      {% for page_num in range(start_page, end_page) %}
                       <li class="page-item {% if page_num == alias_page %}active{% endif %}">
                         <a class="page-link" href="{{ url_for('admin.custom_domain_search.index', query=query, **{'alias_page_' ~ domain.id: page_num}) }}">
                           {{ page_num }}
@@ -848,7 +854,7 @@
                       </li>
                       {% endfor %}
 
-                      {% if alias_page < (alias_count - 1) // 10 + 1 %}
+                      {% if alias_page < total_pages %}
                       <li class="page-item">
                         <a class="page-link" href="{{ url_for('admin.custom_domain_search.index', query=query, **{'alias_page_' ~ domain.id: alias_page + 1}) }}">
                           Next <i class="fa fa-chevron-right"></i>
@@ -880,7 +886,8 @@
                 <span class="badge badge-secondary ml-2">{{ deleted_alias_count }} total</span>
               </h6>
               {% if deleted_alias_count > 10 %}
-              <small class="text-muted">Page {{ deleted_alias_page }} of {{ ((deleted_alias_count - 1) // 10) + 1 }}</small>
+              {% set total_deleted_pages = ((deleted_alias_count - 1) // 10 + 1) if deleted_alias_count > 0 else 1 %}
+              <small class="text-muted">Page {{ deleted_alias_page }} of {{ total_deleted_pages }}</small>
               {% endif %}
             </div>
             <div class="card-body p-0">
@@ -928,7 +935,9 @@
                       </li>
                       {% endif %}
 
-                      {% for page_num in range(max(1, deleted_alias_page - 2), min(deleted_alias_page + 3, (deleted_alias_count - 1) // 10 + 1)) %}
+                      {% set start_deleted_page = (deleted_alias_page - 2) if deleted_alias_page - 2 > 1 else 1 %}
+                      {% set end_deleted_page = (deleted_alias_page + 3) if deleted_alias_page + 3 < total_deleted_pages else total_deleted_pages %}
+                      {% for page_num in range(start_deleted_page, end_deleted_page) %}
                       <li class="page-item {% if page_num == deleted_alias_page %}active{% endif %}">
                         <a class="page-link" href="{{ url_for('admin.custom_domain_search.index', query=query, **{'deleted_alias_page_' ~ domain.id: page_num}) }}">
                           {{ page_num }}
@@ -936,7 +945,7 @@
                       </li>
                       {% endfor %}
 
-                      {% if deleted_alias_page < (deleted_alias_count - 1) // 10 + 1 %}
+                      {% if deleted_alias_page < total_deleted_pages %}
                       <li class="page-item">
                         <a class="page-link" href="{{ url_for('admin.custom_domain_search.index', query=query, **{'deleted_alias_page_' ~ domain.id: deleted_alias_page + 1}) }}">
                           Next <i class="fa fa-chevron-right"></i>

--- a/templates/admin/email_search.html
+++ b/templates/admin/email_search.html
@@ -1461,7 +1461,12 @@
     <div class="card-header d-flex flex-wrap justify-content-between align-items-center header-neutral">
       <h6 class="mb-0">
         <i class="fa fa-at mr-2"></i>Aliases
-        <span class="badge badge-secondary ml-2">{{ alias_count }} total</span>
+        {% if alias_count > helper.ALIAS_DISPLAY_LIMIT %}
+          <span class="badge badge-danger ml-2" title="Unusually high alias count">{{ alias_count }} total</span>
+          <small class="text-danger ml-1"><i class="fa fa-exclamation-triangle mr-1"></i>High alias count</small>
+        {% else %}
+          <span class="badge badge-secondary ml-2">{{ alias_count }} total</span>
+        {% endif %}
         {% if alias_count > page_size %}
 
           <small class="text-muted ml-1">(showing {{ page_size }}, page {{ current_page }}/{{ total_pages }})</small>

--- a/tests/admin/test_custom_domain_search.py
+++ b/tests/admin/test_custom_domain_search.py
@@ -2,6 +2,7 @@
 
 from flask import url_for
 
+from app.admin.custom_domain_search import CustomDomainSearchResult
 from app.db import Session
 from app.models import User, CustomDomain
 from tests.utils import create_new_user, random_token
@@ -121,8 +122,24 @@ def test_custom_domain_search_by_user_email(flask_client):
     assert domain2.domain.encode() in r.data
 
 
+def test_custom_domain_search_by_domain_id(flask_client):
+    """Test searching for a custom domain by its ID."""
+    login_admin(flask_client)
+
+    test_user = create_new_user()
+    domain = create_custom_domain(test_user, f"bydomainid-{random_token(8)}.com")
+    Session.commit()
+
+    r = flask_client.get(
+        url_for("admin.custom_domain_search.index"),
+        query_string={"query": str(domain.id)},
+    )
+    assert r.status_code == 200
+    assert domain.domain.encode() in r.data
+
+
 def test_custom_domain_search_by_user_id(flask_client):
-    """Test searching for custom domains by user ID."""
+    """Test searching for custom domains by user ID using uid: prefix."""
     login_admin(flask_client)
 
     # Create a user with a custom domain
@@ -132,7 +149,7 @@ def test_custom_domain_search_by_user_id(flask_client):
 
     r = flask_client.get(
         url_for("admin.custom_domain_search.index"),
-        query_string={"query": str(test_user.id)},
+        query_string={"query": f"uid:{test_user.id}"},
     )
     assert r.status_code == 200
     assert domain.domain.encode() in r.data
@@ -293,3 +310,140 @@ def test_custom_domain_search_user_without_domains(flask_client):
     assert r.status_code == 200
     # Should show no domains found since user has no domains
     assert b"No custom domains found" in r.data
+
+
+# ============================================================================
+# Unit tests for CustomDomainSearchResult.search
+# ============================================================================
+
+
+def test_search_by_domain_id_found(flask_client):
+    """Plain integer finds domain by ID."""
+    test_user = create_new_user()
+    domain = create_custom_domain(test_user, f"unitid-{random_token(8)}.com")
+    Session.commit()
+
+    result = CustomDomainSearchResult.search(str(domain.id))
+
+    assert not result.no_match
+    assert len(result.domains) == 1
+    assert result.domains[0].domain.id == domain.id
+    assert not result.found_by_regex
+
+
+def test_search_by_domain_id_not_found(flask_client):
+    """Plain integer with no matching domain returns no match."""
+    result = CustomDomainSearchResult.search("999999999")
+
+    assert result.no_match
+    assert result.domains == []
+
+
+def test_search_by_user_email_found(flask_client):
+    """Query with @ searches by user email."""
+    test_user = create_new_user(email=f"unitsearch_{random_token(8)}@example.com")
+    domain = create_custom_domain(test_user, f"unitemail-{random_token(8)}.com")
+    Session.commit()
+
+    result = CustomDomainSearchResult.search(test_user.email)
+
+    assert not result.no_match
+    assert len(result.domains) == 1
+    assert result.domains[0].domain.id == domain.id
+    assert not result.found_by_regex
+
+
+def test_search_by_user_email_not_found(flask_client):
+    """Query with @ for non-existent email returns no match."""
+    result = CustomDomainSearchResult.search(f"nobody_{random_token(8)}@example.com")
+
+    assert result.no_match
+    assert result.domains == []
+
+
+def test_search_by_user_email_no_domains(flask_client):
+    """Query with @ for a user with no domains returns no match."""
+    test_user = create_new_user(email=f"nodom_{random_token(8)}@example.com")
+    Session.commit()
+
+    result = CustomDomainSearchResult.search(test_user.email)
+
+    assert result.no_match
+    assert result.domains == []
+
+
+def test_search_by_uid_found(flask_client):
+    """uid:<int> searches by user ID."""
+    test_user = create_new_user()
+    domain = create_custom_domain(test_user, f"unituid-{random_token(8)}.com")
+    Session.commit()
+
+    result = CustomDomainSearchResult.search(f"uid:{test_user.id}")
+
+    assert not result.no_match
+    assert len(result.domains) == 1
+    assert result.domains[0].domain.id == domain.id
+    assert not result.found_by_regex
+
+
+def test_search_by_uid_not_found(flask_client):
+    """uid:<int> with no matching user returns no match."""
+    result = CustomDomainSearchResult.search("uid:999999999")
+
+    assert result.no_match
+    assert result.domains == []
+
+
+def test_search_by_uid_invalid_format(flask_client):
+    """uid: with non-integer suffix returns no match without raising."""
+    result = CustomDomainSearchResult.search("uid:notanumber")
+
+    assert result.no_match
+    assert result.domains == []
+
+
+def test_search_by_uid_user_without_domains(flask_client):
+    """uid:<int> for a user with no domains returns no match."""
+    test_user = create_new_user()
+    Session.commit()
+
+    result = CustomDomainSearchResult.search(f"uid:{test_user.id}")
+
+    assert result.no_match
+    assert result.domains == []
+
+
+def test_search_by_domain_name_found(flask_client):
+    """Exact domain name returns matching domain."""
+    test_user = create_new_user()
+    domain = create_custom_domain(test_user, f"unitexact-{random_token(8)}.com")
+    Session.commit()
+
+    result = CustomDomainSearchResult.search(domain.domain)
+
+    assert not result.no_match
+    assert len(result.domains) == 1
+    assert result.domains[0].domain.id == domain.id
+    assert not result.found_by_regex
+
+
+def test_search_by_regex_found(flask_client):
+    """Non-matching exact name falls through to regex search."""
+    test_user = create_new_user()
+    prefix = f"unitregex{random_token(4)}"
+    domain = create_custom_domain(test_user, f"{prefix}-abc.com")
+    Session.commit()
+
+    result = CustomDomainSearchResult.search(f"{prefix}-.*\\.com")
+
+    assert not result.no_match
+    assert any(d.domain.id == domain.id for d in result.domains)
+    assert result.found_by_regex
+
+
+def test_search_no_match_returns_no_match(flask_client):
+    """Query that matches nothing returns no_match=True."""
+    result = CustomDomainSearchResult.search(f"nomatch-{random_token(16)}.com")
+
+    assert result.no_match
+    assert result.domains == []


### PR DESCRIPTION
  - Fix admin custom domain search to accept domain ID as query.
  - Add uid:<int> syntax to search custom domains by user ID.
  - Update search placeholder and help text to match.
  - Add warning badge in email search when alias count is unusually high.
  - Log message serialization errors only when all policies fail.