### PR TITLE
fix: unsubscribe links encoding

### DIFF
--- a/app/handler/unsubscribe_encoder.py
+++ b/app/handler/unsubscribe_encoder.py
@@ -97,7 +97,7 @@ class UnsubscribeEncoder:
             UnsubscribeAction.OriginalUnsubscribeMailto,
         ):
             encoded = UnsubscribeEncoder.encode_subject(action, data)
-            return f"{config.URL}/dashboard/unsubscribe/encoded?data={encoded}"
+            return f"{config.URL}/dashboard/unsubscribe/encoded/{encoded}"
 
     @staticmethod
     def _get_signer() -> itsdangerous.Signer:

--- a/tests/handler/test_unsubscribe_encoder.py
+++ b/tests/handler/test_unsubscribe_encoder.py
@@ -65,7 +65,7 @@ legacy_mail_or_link_test_data = [
         UnsubscribeData(UnsubscribeAction.UnsubscribeNewsletter, 83),
     ),
     (
-        f"{config.URL}/dashboard/unsubscribe/encoded?data=un.WzQsIFswLCAxLCAiYUBiLmMiLCAic3ViamVjdCJdXQ.aU3T5XNzJIG4LDm6-pqJk4vxxJxpgVYzc9MEFQ",
+        f"{config.URL}/dashboard/unsubscribe/encoded/un.WzQsIFswLCAxLCAiYUBiLmMiLCAic3ViamVjdCJdXQ.aU3T5XNzJIG4LDm6-pqJk4vxxJxpgVYzc9MEFQ",
         False,
         UnsubscribeData(
             UnsubscribeAction.OriginalUnsubscribeMailto,

--- a/tests/handler/test_unsubscribe_generator.py
+++ b/tests/handler/test_unsubscribe_generator.py
@@ -183,7 +183,7 @@ def generate_unsub_preserve_original_data() -> Iterable:
         contact.id,
         False,
         "<mailto:test@test.com?subject=hello>",
-        f"<{config.URL}/dashboard/unsubscribe/encoded?data={unsub_data}>",
+        f"<{config.URL}/dashboard/unsubscribe/encoded/{unsub_data}>",
     )
     yield (alias.id, contact.id, True, None, None)
     yield (alias.id, contact.id, False, None, None)


### PR DESCRIPTION
Fix a bug that generated unsubscribe links with a different encoding than the ones we had a registered handler for