### PR TITLE
docs: document LANDING_PAGE_URL for self-hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,9 @@ Some have "dummy" values, fill them up if you want to enable these features (Pad
 # WebApp URL
 URL=http://app.mydomain.com
 
+# URL of the landing page linked from the app and emails (e.g. referral links); defaults to https://simplelogin.io
+LANDING_PAGE_URL=http://mydomain.com
+
 # domain used to create alias
 EMAIL_DOMAIN=mydomain.com
 

--- a/docs/ssl.md
+++ b/docs/ssl.md
@@ -39,6 +39,7 @@ Make sure to replace app.mydomain.com with your own domain.
 ### Updating `simplelogin.env`
 
 Make sure to change the `URL` in `simplelogin.env` to `https://app.mydomain.com`, otherwise not all page assets will load securely, and some functionality (e.g. Webauthn) will break.
+If you set `LANDING_PAGE_URL`, update it to `https://mydomain.com` as well.
 You will need to reload the docker containers for this to take effect.
 
 ## HTTP Strict Transport Security (HSTS)


### PR DESCRIPTION
## What

Documents the `LANDING_PAGE_URL` environment variable, which is read in `app/config.py` (defaults to `https://simplelogin.io`) but isn't mentioned in the self-hosting docs:

- Add `LANDING_PAGE_URL` to the `simplelogin.env` example in the README.
- Note the matching `https://` change in `docs/ssl.md` alongside the existing `URL` note.

## Why

`LANDING_PAGE_URL` is injected into templates and emails as the marketing-site link (e.g. referral links `LANDING_PAGE_URL?slref=...`). Without setting it, a self-hosted instance links back to `simplelogin.io` instead of the operator's own domain. Documentation-only change.