### PR TITLE
Check SPF is aligned if the fallback from is used in the reply path

### DIFF
--- a/app/email_utils.py
+++ b/app/email_utils.py
@@ -1485,6 +1485,7 @@ def spf_pass(
     alias: Alias,
     contact_email: str,
     msg: Message,
+    strict: bool = False,
 ) -> bool:
     ip = msg[headers.SL_CLIENT_IP]
     if ip:
@@ -1493,10 +1494,13 @@ def spf_pass(
             r = spf.check2(i=ip, s=envelope.mail_from, h=None)
         except Exception:
             LOG.e("SPF error, mailbox %s, ip %s", mailbox.email, ip)
+            if strict:
+                return False
         else:
             # TODO: Handle temperr case (e.g. dns timeout)
-            # only an absolute pass, or no SPF policy at all is 'valid'
-            if r[0] not in ["pass", "none"]:
+            # only an absolute pass, or no SPF policy at all is 'valid' -- unless `strict`
+            valid_results = ["pass"] if strict else ["pass", "none"]
+            if r[0] not in valid_results:
                 LOG.w(
                     "SPF fail for mailbox %s, reason %s, failed IP %s",
                     mailbox.email,
@@ -1538,6 +1542,8 @@ def spf_pass(
             mailbox.email,
             contact_email,
         )
+        if strict:
+            return False
 
     return True
 

--- a/app/mailbox_utils.py
+++ b/app/mailbox_utils.py
@@ -4,7 +4,7 @@ import uuid
 from email.message import Message
 from enum import Enum
 from io import BytesIO
-from typing import Optional
+from typing import Optional, Tuple
 
 import arrow
 from aiosmtpd.smtp import Envelope
@@ -514,22 +514,21 @@ def __get_alias_mailbox_from_email_or_canonical_email(
 
 def get_mailbox_for_reply_phase(
     envelope_mail_from: str, header_mail_from: str, alias
-) -> Optional[Mailbox]:
-    """return the corresponding mailbox given the mail_from and alias
-    Usually the mail_from=mailbox.email but it can also be one of the authorized address
-    """
+) -> Tuple[Optional[Mailbox], bool]:
     mbox = __get_alias_mailbox_from_email_or_canonical_email(envelope_mail_from, alias)
     if mbox is not None:
-        return mbox
+        return mbox, False
     if not header_mail_from:
-        return None
+        return None, False
     envelope_from_domain = get_email_domain_part(envelope_mail_from)
     header_from_domain = get_email_domain_part(header_mail_from)
     if envelope_from_domain != header_from_domain:
-        return None
+        return None, False
     # For services that use VERP sending (envelope from has encoded data to account for bounces)
     # if the domain is the same in the header from as the envelope from we can use the header from
-    return __get_alias_mailbox_from_email_or_canonical_email(header_mail_from, alias)
+    mbox = __get_alias_mailbox_from_email_or_canonical_email(header_mail_from, alias)
+    # Second param returns whether the mbox comes from the From header as a fallback
+    return mbox, mbox is not None
 
 
 def count_mailbox_aliases(mailbox: Mailbox) -> int:

--- a/email_handler.py
+++ b/email_handler.py
@@ -1095,7 +1095,7 @@ def handle_reply(
         return False, dmarc_delivery_status
 
     # Anti-spoofing
-    mailbox = get_mailbox_for_reply_phase(
+    mailbox, used_header_fallback = get_mailbox_for_reply_phase(
         envelope.mail_from, get_header_unicode(msg[headers.FROM]), alias
     )
     if not mailbox:
@@ -1118,15 +1118,24 @@ def handle_reply(
         LOG.i(f"User {user} tried to send a mail from admin disabled mailbox {mailbox}")
         return False, status.E207
 
-    if (
-        config.ENFORCE_SPF
-        and mailbox.force_spf
-        and not alias.disable_email_spoofing_check
-    ):
-        if not spf_pass(envelope, mailbox, user, alias, contact.website_email, msg):
-            # cannot use 4** here as sender will retry.
-            # cannot use 5** because that generates bounce report
-            return True, status.E201
+    if not alias.disable_email_spoofing_check:
+        if used_header_fallback:
+            # The mailbox was picked by trusting the From: header. In that case force spf pass
+            # to avoid anyone sharing a domain with an owning mailbox impersonating by just
+            # setting the From: header.
+            if not spf_pass(
+                envelope, mailbox, user, alias, contact.website_email, msg, strict=True
+            ):
+                LOG.i(
+                    "Skipping delivering reply mail since spf does not pass and mbox comes from header"
+                )
+                return True, status.E201
+        elif config.ENFORCE_SPF and mailbox.force_spf:
+            LOG.i(
+                "Skipping delivering reply mail since spf does not pass and mbox comes from header"
+            )
+            if not spf_pass(envelope, mailbox, user, alias, contact.website_email, msg):
+                return True, status.E201
 
     Alias.lock_for_update(contact.alias_id)
     email_log = EmailLog.create(

--- a/tests/test_mailbox_utils.py
+++ b/tests/test_mailbox_utils.py
@@ -473,11 +473,15 @@ def test_get_mailbox_from_mail_from(flask_client):
     alias = Alias.create_new_random(user)
     Session.commit()
 
-    mb = get_mailbox_for_reply_phase(user.email, "", alias)
+    mb, used_header_fallback = get_mailbox_for_reply_phase(user.email, "", alias)
     assert mb.email == user.email
+    assert used_header_fallback is False
 
-    mb = get_mailbox_for_reply_phase("unauthorized@gmail.com", "", alias)
+    mb, used_header_fallback = get_mailbox_for_reply_phase(
+        "unauthorized@gmail.com", "", alias
+    )
     assert mb is None
+    assert used_header_fallback is False
 
     # authorized address
     AuthorizedAddress.create(
@@ -486,8 +490,11 @@ def test_get_mailbox_from_mail_from(flask_client):
         email="unauthorized@gmail.com",
         commit=True,
     )
-    mb = get_mailbox_for_reply_phase("unauthorized@gmail.com", "", alias)
+    mb, used_header_fallback = get_mailbox_for_reply_phase(
+        "unauthorized@gmail.com", "", alias
+    )
     assert mb.email == user.email
+    assert used_header_fallback is False
 
 
 def test_get_mailbox_from_mail_from_for_canonical_email(flask_client):
@@ -503,11 +510,13 @@ def test_get_mailbox_from_mail_from_for_canonical_email(flask_client):
     alias = Alias.create(user_id=user.id, email=random_email(), mailbox_id=mbox.id)
     Session.flush()
 
-    mb = get_mailbox_for_reply_phase(email, "", alias)
+    mb, used_header_fallback = get_mailbox_for_reply_phase(email, "", alias)
     assert mb.email == canonical_email
+    assert used_header_fallback is False
 
-    mb = get_mailbox_for_reply_phase(canonical_email, "", alias)
+    mb, used_header_fallback = get_mailbox_for_reply_phase(canonical_email, "", alias)
     assert mb.email == canonical_email
+    assert used_header_fallback is False
 
 
 def test_get_mailbox_from_mail_from_coming_from_header_if_domain_is_aligned(
@@ -521,8 +530,11 @@ def test_get_mailbox_from_mail_from_coming_from_header_if_domain_is_aligned(
     alias = Alias.create(user_id=user.id, email=random_email(), mailbox_id=mbox.id)
     Session.flush()
 
-    mb = get_mailbox_for_reply_phase(envelope_from, mail_from, alias)
+    mb, used_header_fallback = get_mailbox_for_reply_phase(
+        envelope_from, mail_from, alias
+    )
     assert mb.email == mail_from
+    assert used_header_fallback is True
 
 
 def test_get_mailbox_from_mail_from_coming_from_header_if_domain_is_not_aligned(
@@ -536,8 +548,11 @@ def test_get_mailbox_from_mail_from_coming_from_header_if_domain_is_not_aligned(
     alias = Alias.create(user_id=user.id, email=random_email(), mailbox_id=mbox.id)
     Session.flush()
 
-    mb = get_mailbox_for_reply_phase(envelope_from, mail_from, alias)
+    mb, used_header_fallback = get_mailbox_for_reply_phase(
+        envelope_from, mail_from, alias
+    )
     assert mb is None
+    assert used_header_fallback is False
 
 
 @mail_sender.store_emails_test_decorator


### PR DESCRIPTION
If we use the fallback from header in the reply path ensure the domain passes a strict spf check.