### PR TITLE
Fix: declare protobuf/cachetools as direct deps, modernize google-api-python-client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,10 @@ dependencies = [
   "pyotp ~= 2.4.0",
   "flask_profiler ~= 1.8.1",
   "facebook-sdk ~= 3.1.0",
-  "google-api-python-client ~= 1.12.3",
-  "google-auth-httplib2 ~= 0.0.4",
+  "google-api-python-client >= 2.100, < 3",
+  "google-auth-httplib2 >= 0.2.0, < 1.0",
+  "protobuf >= 4.25, < 6",
+  "cachetools >= 5.0, < 6",
   "python-gnupg ~= 0.4.6",
   "webauthn ~= 0.4.7",
 

--- a/uv.lock
+++ b/uv.lock
@@ -249,11 +249,11 @@ wheels = [
 
 [[package]]
 name = "cachetools"
-version = "4.1.1"
+version = "5.5.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fc/c8/0b52cf3132b4b85c9e83faa3e4d375575afeb3a1710c40b2b2cd2a3e5635/cachetools-4.1.1.tar.gz", hash = "sha256:bbaa39c3dede00175df2dc2b03d0cf18dd2d32a7de7beb68072d13043c9edb20", size = 23574, upload-time = "2020-06-28T19:42:39.37Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/81/3747dad6b14fa2cf53fcf10548cf5aea6913e96fab41a3c198676f8948a5/cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4", size = 28380, upload-time = "2025-02-20T21:01:19.524Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/5c/f3aa86b6d5482f3051b433c7616668a9b96fbe49a622210e2c9781938a5c/cachetools-4.1.1-py3-none-any.whl", hash = "sha256:513d4ff98dd27f85743a8dc0e92f55ddb1b49e060c2d5961512855cda2c01a98", size = 10960, upload-time = "2020-06-28T19:42:38.034Z" },
+    { url = "https://files.pythonhosted.org/packages/72/76/20fa66124dbe6be5cafeb312ece67de6b61dd91a0247d1ea13db4ebb33c2/cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a", size = 10080, upload-time = "2025-02-20T21:01:16.647Z" },
 ]
 
 [[package]]
@@ -766,80 +766,71 @@ wheels = [
 
 [[package]]
 name = "google-api-core"
-version = "1.22.2"
+version = "2.30.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-auth" },
     { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
     { name = "protobuf" },
-    { name = "pytz" },
     { name = "requests" },
-    { name = "setuptools" },
-    { name = "six" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/0b/992fd8a7fcc8b6498b85ec771237a7306e84f3523d9f34c9ea47ca00d82a/google-api-core-1.22.2.tar.gz", hash = "sha256:779107f17e0fef8169c5239d56a8fbff03f9f72a3893c0c9e5842ec29dfedd54", size = 92933, upload-time = "2020-09-03T19:05:33.379Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/ce/502a57fb0ec752026d24df1280b162294b22a0afb98a326084f9a979138b/google_api_core-2.30.3.tar.gz", hash = "sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b", size = 177001, upload-time = "2026-04-10T00:41:28.035Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/45/a5707ce2cbd6681c09e69a0ce10d9bebe98e0231c458a4dc652670f3584f/google_api_core-1.22.2-py2.py3-none-any.whl", hash = "sha256:67e33a852dcca7cb7eff49abc35c8cc2c0bb8ab11397dc8306d911505cae2990", size = 91155, upload-time = "2020-09-03T19:05:31.714Z" },
+    { url = "https://files.pythonhosted.org/packages/03/15/e56f351cf6ef1cfea58e6ac226a7318ed1deb2218c4b3cc9bd9e4b786c5a/google_api_core-2.30.3-py3-none-any.whl", hash = "sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8", size = 173274, upload-time = "2026-04-09T22:57:16.198Z" },
 ]
 
 [[package]]
 name = "google-api-python-client"
-version = "1.12.3"
+version = "2.199.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core" },
     { name = "google-auth" },
     { name = "google-auth-httplib2" },
     { name = "httplib2" },
-    { name = "six" },
     { name = "uritemplate" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/76/5e27bab1fb7e449fe3564019f36c96dd0fc0240132e9a8744835ec6c3567/google-api-python-client-1.12.3.tar.gz", hash = "sha256:844ef76bda585ea0ea2d5e7f8f9a0eb10d6e2eba66c4fea0210ec7843941cb1a", size = 146168, upload-time = "2020-09-29T16:20:58.361Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/ff/c58d475046b552754a5ee24d98912506b07ea7ac7f0a434b327ad194ca32/google_api_python_client-2.199.0.tar.gz", hash = "sha256:8150816e22e01b36aa4b7523cdc1a2d2164e81c4de8a9b338785d7ecb4390ec2", size = 15394941, upload-time = "2026-08-20T21:38:39.745Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/9a/2976a839fffb35d341bdce0cb06f1f9da80b148bfe209c55d3e34e5cc146/google_api_python_client-1.12.3-py2.py3-none-any.whl", hash = "sha256:5b3f4908c041f3109135841cf7e49fc4477f26f7d02b6db72753a17f8b338d01", size = 61278, upload-time = "2020-09-29T16:20:56.731Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/42/c443badc33d972ee0e0adcd481c32a71f15d3e04c23a7a3d758e4018c633/google_api_python_client-2.199.0-py3-none-any.whl", hash = "sha256:1d2fa0e7f9d68f063b1a9ff7ed290d6e6c93176260487bf3a991e41534ca23a3", size = 15991965, upload-time = "2026-08-20T21:38:37.274Z" },
 ]
 
 [[package]]
 name = "google-auth"
-version = "1.22.0"
+version = "2.47.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
-    { name = "cachetools" },
     { name = "pyasn1-modules" },
     { name = "rsa" },
-    { name = "setuptools" },
-    { name = "six" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/3b/35bdcefe341d5ae08f32ac3559d6c99ebaef5765939b43c425f5b32e4d96/google-auth-1.22.0.tar.gz", hash = "sha256:a73e6fb6d232ed1293ef9a5301e6f8aada7880d19c65d7f63e130dc50ec05593", size = 119967, upload-time = "2020-09-28T22:49:17.29Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/3c/ec64b9a275ca22fa1cd3b6e77fefcf837b0732c890aa32d2bd21313d9b33/google_auth-2.47.0.tar.gz", hash = "sha256:833229070a9dfee1a353ae9877dcd2dec069a8281a4e72e72f77d4a70ff945da", size = 323719, upload-time = "2026-01-06T21:55:31.045Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/3f/7fbf002e01c17c35cb68de64ab2cfc069fd6aca5b8fdc44a34490d993279/google_auth-1.22.0-py2.py3-none-any.whl", hash = "sha256:e86e72142d939a8d90a772947268aacc127ab7a1d1d6f3e0fecca7a8d74d8257", size = 114697, upload-time = "2020-09-28T22:49:15.719Z" },
+    { url = "https://files.pythonhosted.org/packages/db/18/79e9008530b79527e0d5f79e7eef08d3b179b7f851cfd3a2f27822fbdfa9/google_auth-2.47.0-py3-none-any.whl", hash = "sha256:c516d68336bfde7cf0da26aab674a36fedcf04b37ac4edd59c597178760c3498", size = 234867, upload-time = "2026-01-06T21:55:28.6Z" },
 ]
 
 [[package]]
 name = "google-auth-httplib2"
-version = "0.0.4"
+version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-auth" },
     { name = "httplib2" },
-    { name = "six" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6c/5e/97a5e7573457020351a275c74c559dbe2ebe1c606119f991541c98ffa651/google-auth-httplib2-0.0.4.tar.gz", hash = "sha256:8d092cc60fb16517b12057ec0bba9185a96e3b7169d86ae12eae98e645b7bc39", size = 10287, upload-time = "2020-07-07T19:08:33.175Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/4e/992849016f8b0c27fb604aafd0a7a724db16128906197bd1245c6f18e6a1/google_auth_httplib2-0.0.4-py2.py3-none-any.whl", hash = "sha256:aeaff501738b289717fac1980db9711d77908a6c227f60e4aa1923410b43e2ee", size = 9117, upload-time = "2020-07-07T19:08:31.75Z" },
+    { url = "https://files.pythonhosted.org/packages/20/33/e697a69f13bfd448d33a374231b89cbbb203dedfb4aae9d26126be6f6c72/google_auth_httplib2-0.4.2-py3-none-any.whl", hash = "sha256:4298dd6b1415972d0c464b7177e6a69a595e7aec5b972222ecdca342f6009647", size = 9529, upload-time = "2026-08-24T21:55:05.843Z" },
 ]
 
 [[package]]
 name = "googleapis-common-protos"
-version = "1.52.0"
+version = "1.75.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/3f/a1282d82def57e0c28bab597d25785774a4e64433aac9cc136e65c500da8/googleapis-common-protos-1.52.0.tar.gz", hash = "sha256:560716c807117394da12cecb0a54da5a451b5cf9866f1d37e9a5e2329a665351", size = 39383, upload-time = "2020-06-04T02:49:11.342Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/74/3956721ea1eb4bcf7502a311fdaa60b85bd751de4e57d1943afe9b334141/googleapis_common_protos-1.52.0-py2.py3-none-any.whl", hash = "sha256:c8961760f5aad9a711d37b675be103e0cc4e9a39327e0d6d857872f698403e24", size = 100172, upload-time = "2020-06-04T02:49:09.844Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
 ]
 
 [[package]]
@@ -1335,6 +1326,18 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.28.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/3e/29e0d6a2c5adde6ab5772253fd16ab346324026b89a66e354689c86d0584/proto_plus-1.28.2.tar.gz", hash = "sha256:26d843eb99c1e32fdf1d20ff0faae56607f7748fe774acf9ecd5cfe6c6472501", size = 58063, upload-time = "2026-07-22T16:28:29.119Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/84/4e9a53a062d4073c74897a6bd20fff74d55307341b3e85c081002462b3ef/proto_plus-1.28.2-py3-none-any.whl", hash = "sha256:b874236fcac2358f601e4330bcb76cb8b89c851303ccf4078408b3d4774d1c52", size = 50693, upload-time = "2026-07-22T16:28:24.059Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "5.27.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1786,6 +1789,7 @@ dependencies = [
     { name = "bcrypt" },
     { name = "blinker" },
     { name = "boto3" },
+    { name = "cachetools" },
     { name = "coinbase-commerce" },
     { name = "coloredlogs" },
     { name = "cryptography" },
@@ -1819,6 +1823,7 @@ dependencies = [
     { name = "newrelic-telemetry-sdk" },
     { name = "pgpy" },
     { name = "phpserialize" },
+    { name = "protobuf" },
     { name = "psycopg2-binary" },
     { name = "pycryptodome" },
     { name = "pyopenssl" },
@@ -1865,6 +1870,7 @@ requires-dist = [
     { name = "bcrypt", specifier = "~=3.2.0" },
     { name = "blinker", specifier = "~=1.9.0" },
     { name = "boto3", specifier = "~=1.35.37" },
+    { name = "cachetools", specifier = ">=5.0,<6" },
     { name = "coinbase-commerce", specifier = "~=1.0.1" },
     { name = "coloredlogs", specifier = "~=14.0" },
     { name = "cryptography", specifier = "~=37.0.1" },
@@ -1885,8 +1891,8 @@ requires-dist = [
     { name = "flask-profiler", specifier = "~=1.8.1" },
     { name = "flask-wtf", specifier = "~=0.14.3" },
     { name = "gevent", specifier = "~=24.11.1" },
-    { name = "google-api-python-client", specifier = "~=1.12.3" },
-    { name = "google-auth-httplib2", specifier = "~=0.0.4" },
+    { name = "google-api-python-client", specifier = ">=2.100,<3" },
+    { name = "google-auth-httplib2", specifier = ">=0.2.0,<1.0" },
     { name = "gunicorn", specifier = "~=20.0.4" },
     { name = "ipython", specifier = "~=7.31.1" },
     { name = "itsdangerous", specifier = "~=1.1.0" },
@@ -1898,6 +1904,7 @@ requires-dist = [
     { name = "newrelic-telemetry-sdk", specifier = "~=0.5.0" },
     { name = "pgpy", specifier = "==0.5.4" },
     { name = "phpserialize", specifier = "~=1.3" },
+    { name = "protobuf", specifier = ">=4.25,<6" },
     { name = "psycopg2-binary", specifier = "~=2.9.10" },
     { name = "pycryptodome", specifier = "~=3.9.8" },
     { name = "pyopenssl", specifier = "~=19.1.0" },


### PR DESCRIPTION
Fixes #2797

## Problem

`protobuf` and `cachetools` are used directly in the codebase
(`app/events/generated/event_pb2.py` needs `google.protobuf.runtime_version`,
`app/email_utils.py` imports `cachetools`) but neither is declared as a
direct dependency in `pyproject.toml`. Both currently float in transitively
through the very old `google-api-python-client ~= 1.12.3` pin / its
`google-api-core` chain.

That means the versions that end up in `uv.lock` for these two packages are
whatever the resolver happens to land on for the rest of the graph at lock
time - not something `pyproject.toml` actually guarantees. Re-locking today
(or after adding any unrelated dependency, as reproduced in #2797) resolves
`protobuf` down to `3.20.3`, which does not have the `runtime_version`
module that the checked-in generated `event_pb2.py` requires, and the app,
`email_handler.py`, and `job_runner.py` all fail at import time with:

```
ImportError: cannot import name 'runtime_version' from 'google.protobuf'
```

## Fix

- Declare `protobuf >= 4.25, < 6` directly (matches what `event_pb2.py`
  actually needs).
- Declare `cachetools >= 5.0, < 6` directly (matches actual usage in
  `app/email_utils.py`).
- Bump `google-api-python-client` from the ~2020-era `~= 1.12.3` to
  `>= 2.100, < 3`, and `google-auth-httplib2` from `~= 0.0.4` to
  `>= 0.2.0, < 1.0` accordingly. The only call site,
  `app/api/views/auth.py`'s `googleapiclient.discovery.build("oauth2",
  "v2", credentials=cred)`, is a generic discovery-based call unaffected by
  the major version bump.

With this, `uv lock` resolves cleanly to stable, non-prerelease versions
end to end: `protobuf 5.27.1`, `google-api-core 2.30.3`, `cachetools
5.5.2`.

## Testing

Verified locally before opening this PR (see #2797 for the failure
reproduction on unpatched `master`):

- `uv lock` resolves without conflicts, no dev/pre-release versions pulled
  in.
- Full container build from this branch succeeds.
- `python -c "import email_handler"`, `import job_runner"`,
  `import app.api.views.auth"`, and `from app.events.generated import
  event_pb2` all import cleanly against the built image.
- `gunicorn wsgi:app -w 2` boots both workers and stays up (previously
  crashed immediately on the unpatched dependency set).

## Test plan for reviewers

- [ ] `uv lock` on this branch resolves without needing `--upgrade`
      or pulling any pre-release/dev version
- [ ] `docker build` succeeds
- [ ] App boots and the Google OAuth login code path
      (`app/api/views/auth.py`) still imports/works
